### PR TITLE
Added support to global configurations

### DIFF
--- a/autoNumeric.js
+++ b/autoNumeric.js
@@ -848,8 +848,8 @@
             return this.each(function () {
                 var $this = $(this),
                     settings = $this.data('autoNumeric'), /** attempt to grab 'autoNumeric' settings, if they don't exist returns "undefined". */
-                    tagData = $this.data(); /** attempt to grab HTML5 data, if they don't exist we'll get "undefined".*/
-                if (typeof settings !== 'object') { /** If we couldn't grab settings, create them from defaults and passed options. */
+                    defaults = $.fn.autoNumeric.defaults; /** attempt to grab the default global configuration.*/
+                if (typeof settings !== 'object' && typeof defaults !== 'object') { /** If we couldn't grab settings, create them from defaults and passed options. */
                     var defaults = {
                         /** allowed numeric values
                          * please do not modify
@@ -1279,7 +1279,15 @@
         getSettings: function () {
             var $this = autoGet($(this));
             return $this.eq(0).data('autoNumeric');
-        }
+        },
+		/** configure the default settings to autoNumeric */
+		setDefaults: function (options) {
+			if (typeof options !== 'object') {
+				$.error("You must initialize autoNumeric('init', {options}) prior to calling the 'update' method");
+				return this;
+			}
+            $.fn.autoNumeric.defaults = $.extend({}, $.fn.autoNumeric.defaults, options); /** Merge defaults and options */
+		}
     };
     $.fn.autoNumeric = function (method) {
         if (methods[method]) {


### PR DESCRIPTION
Allowing to use '$.fn.autoNumeric.defaults' as global configuration of all fields. This allows configurations of localization like '$.autoNumeric.setDefaults($.datepicker.regional['en-US'])', as the same standard of jQuery UI DatePicker.