### PR TITLE
Set bower.json license to MIT like package.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "mask"
   ],
   "description": "autoNumeric is a jQuery plugin that automatically formats currency (money) and numbers as you type on form inputs. It supports most International numeric formats and currency signs including those used in Europe, North and South America, Asia and India (lakhs**).",
-  "license": "http://opensource.org/licenses/mit-license.php",
+  "license": "MIT",
   "dependencies": {
     "jquery": ">=1.7"
   },


### PR DESCRIPTION
I use http://www.webjars.org/bower but webjars seems to not support this url as license for deployment.
