### PR TITLE
set to empty string displaying monetary symbol

### DIFF
--- a/autoNumeric.js
+++ b/autoNumeric.js
@@ -1180,7 +1180,9 @@
                 if (!autoCheck(value, settings)) {
                     value = autoRound('', settings);
                 }
-                value = autoGroup(value, settings);
+                if (value !== '') {
+                    value = autoGroup(value, settings);
+                }
                 if ($input) {
                     return $this.val(value);
                 }


### PR DESCRIPTION
When setting the value of an autoNumeric to '' (an empty string) the dollar symbol shows in the input box with no following numbers
