### PR TITLE
Fix Destroy Event (off)

### DIFF
--- a/autoNumeric.js
+++ b/autoNumeric.js
@@ -1114,6 +1114,11 @@
             return $(this).each(function () {
                 var $this = $(this);
                 $this.removeData('autoNumeric');
+                $this.off("keyup.autoNumeric");
+                $this.off("keydown.autoNumeric");
+                $this.off("keypress.autoNumeric");
+                $this.off("focusin.autoNumeric");
+                $this.off("focusout.autoNumeric");
                 $this.off('autoNumeric');
             });
         },


### PR DESCRIPTION
To remove a namespace event you have to do it individually. (http://api.jquery.com/on/)
If you do not remove all events individually, error an occurs in elements that you use "destroy" and "init" multiple times.