### PR TITLE
Fix autoNumeric('destroy') on 2.0-BETA, closes #234

### DIFF
--- a/autoNumeric-2.0/autoNumeric-2.0-BETA.js
+++ b/autoNumeric-2.0/autoNumeric-2.0-BETA.js
@@ -1541,7 +1541,7 @@
                     $this.val('');
                     autoSave($this, settings, 'wipe');
                     $this.removeData('autoNumeric');
-                    $this.off('autoNumeric');
+                    $this.off('.autoNumeric');
                 }
             });
         },


### PR DESCRIPTION
According to [jQuery documentation](http://api.jquery.com/off/#off-events-selector-handler), events are detached using `.off('.namespace-name')`, not `.off('namespace-name')` (notice the dot)