### PR TITLE
Fix autoNumeric('destroy') in autoNumeric.js, closes #234

### DIFF
--- a/autoNumeric.js
+++ b/autoNumeric.js
@@ -1114,7 +1114,7 @@
             return $(this).each(function () {
                 var $this = $(this);
                 $this.removeData('autoNumeric');
-                $this.off('autoNumeric');
+                $this.off('.autoNumeric');
             });
         },
 


### PR DESCRIPTION
According to [jQuery documentation](http://api.jquery.com/off/#off-events-selector-handler), events are detached using `.off('.namespace-name')`, not `.off('namespace-name')` (notice the dot)

> Note: these changes should be done in autoNumeric.min.js too.