### PR TITLE
fixes #251

### DIFF
--- a/autoNumeric-2.0/autoNumeric-2.0-BETA.js
+++ b/autoNumeric-2.0/autoNumeric-2.0-BETA.js
@@ -1635,10 +1635,13 @@
                         }
                     });
                     $this.on("paste", function (e) {
+                        e.preventDefault();
                         holder = getHolder($this);
                         var $settings = holder.settingsClone;
-                        e.preventDefault();
-                        var pastedValue = autoStrip(e.originalEvent.clipboardData.getData('text/plain'), $settings);
+                        var currentValue = this.value || '';
+                        var prefix = currentValue.substring(0, this.selectionStart || 0);
+                        var suffix = currentValue.substring(this.selectionEnd || 0, currentValue.length);
+                        var pastedValue =  autoStrip(prefix + e.originalEvent.clipboardData.getData('text/plain') + suffix, $settings);
                         if (pastedValue !== '' && !isNaN(pastedValue)) {
                             $this.autoNumeric("set", pastedValue);
                             $this.trigger('input');

--- a/autoNumeric-2.0/autoNumeric-2.0-BETA.js
+++ b/autoNumeric-2.0/autoNumeric-2.0-BETA.js
@@ -1637,13 +1637,11 @@
                     $this.on("paste", function (e) {
                         holder = getHolder($this);
                         var $settings = holder.settingsClone;
-                        if ($settings.mouseUp) {
-                            window.setTimeout(function()
-                            {
-                                var pastedValue = autoStrip($this.val(), $settings);
-                                $this.autoNumeric("set", pastedValue);
-
-                            }, 1);
+                        e.preventDefault();
+                        var pastedValue = autoStrip(e.originalEvent.clipboardData.getData('text/plain'), $settings);
+                        if (pastedValue !== '' && !isNaN(pastedValue)) {
+                            $this.autoNumeric("set", pastedValue);
+                            $this.trigger('input');
                         }
                     });
                     $this.on("mouseup", function (e) {


### PR DESCRIPTION
- when pasting either by keyboard or mouse, if the pasted text is valid do `.autoNumeric('set', pastedValue)` and `.trigger('input')`, otherwise, don't do those things and input is not visually updated.
- when handling `input` event after paste, `.autoNumeric('get')` will show the new value.