### PR TITLE
Change the default value for the `lZero` option.

### DIFF
--- a/src/autoNumeric.js
+++ b/src/autoNumeric.js
@@ -262,7 +262,7 @@ const defaultSettings = {
      * lZero: "deny", - allows only one leading zero on values less than one
      * lZero: "keep", - allows leading zeros to be entered. on focusout zeros will be retained.
      */
-    lZero: 'allow',
+    lZero: 'deny',
 
     /* Determine if the default value will be formatted on initialization.
      * true = automatically formats the default value on initialization

--- a/test/unit/autoNumeric.spec.js
+++ b/test/unit/autoNumeric.spec.js
@@ -88,7 +88,7 @@ describe('The autoNumeric object', () => {
         aPad         : true,
         nBracket     : null,
         wEmpty       : 'focus',
-        lZero        : 'allow',
+        lZero        : 'deny',
         aForm        : true,
         sNumber      : false,
         anDefault    : null,


### PR DESCRIPTION
It's more logical to prevent the user entering zeroes that will get discarded anyway, while most currencies and numbers are never written like '000.1234%' or '001.234.567,89 €'.