### PR TITLE
Rename many functions with more explicit names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 ### Change log for autoNumeric:
 
+### "2.0.0-beta.13"
++ Fix issue #228 Do not modify the current selection when trying to input an invalid character
++ Mass rename functions to gives them a more explicit name :
+
+| Old name                    |          | New name |
+| :---------------- | :------------ | :-----------:  |
+| autoCheck()       | -> | checkIfInRangeWithOverrideOption()                       |
+| autoRound()       | -> | roundValue()                                             |
+| autoGroup()       | -> | addGroupSeparators()                                     |
+| fixNumber()       | -> | modifyNegativeSignAndDecimalCharacterForRawValue()       |
+| presentNumber()   | -> | modifyNegativeSignAndDecimalCharacterForFormattedValue() |
+| negativeBracket() | -> | toggleNegativeBracket()                                  |
+| autoGet()         | -> | getCurrentElement()                                      |
+| getHolder()       | -> | getAutoNumericHolder()                                   |
+| autoSave()        | -> | saveValueToPersistentStorage()                           |
+| _setPosition()    | -> | _setCaretPosition()                                      |
+| _signPosition()   | -> | _getSignPosition()                                       |
+| _formatQuick()    | -> | _formatValue()                                           |
+
 ### "2.0.0-beta.12"
 + Modify the `validate()` function to show a warning when `decimalPlacesOverride` is greater than `decimalPlacesShownOnFocus`.
 + Implement feature request #183 that manage invalid results when trying to paste any number. This adds the `onInvalidPaste` option that can accept the `error`, `ignore`, `clamp`, `truncate` and `replace` value.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autonumeric",
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.13",
   "description": "autoNumeric is a jQuery plugin that automatically formats currency (money) and numbers as you type on form inputs. It supports most international numeric formats and currency signs including those used in Europe, North and South America, Asia and India's' lakhs.",
   "main": "src/autoNumeric.js",
   "typings": "typings.d.ts",

--- a/src/autoNumeric.js
+++ b/src/autoNumeric.js
@@ -1,8 +1,8 @@
 /**
  *               autoNumeric.js
  *
- * @version      2.0-beta.12
- * @date         2016-12-21 UTC 13:00
+ * @version      2.0-beta.13
+ * @date         2016-12-22 UTC 07:00
  *
  * @author       Bob Knothe
  * @contributors Sokolov Yura and other Github users, cf. AUTHORS.md.


### PR DESCRIPTION
Remove unneeded variable redeclaration (in `truncateDecimal()` and other functions).
Fix the return value of `_processCharacterInsertion()`, and how some part of `onKeypress()` were never called.
Rename `autoCheck()` to `checkIfInRangeWithOverrideOption()`.
Rename `autoRound()` to `roundValue()`.
Rename `autoGroup()` to `addGroupSeparators()`.
Rename `fixNumber()` to `modifyNegativeSignAndDecimalCharacterForRawValue()`.
Rename `presentNumber()` to `modifyNegativeSignAndDecimalCharacterForFormattedValue()`.
Rename `negativeBracket()` to `toggleNegativeBracket()`.
Rename `autoGet()` to `getCurrentElement()`.
Rename `getHolder()` to `getAutoNumericHolder()`.
Rename `autoSave()` to `saveValueToPersistentStorage()`.
Rename `_setPosition()` to `_setCaretPosition()`.
Rename `_signPosition()` to `_getSignPosition()`.
Rename `_formatQuick()` to `_formatValue()`.