### PR TITLE
Add specific `npm` commands to run unit tests in only one browser at a time

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     "clean": "npm run clean:build && npm run clean:coverage && npm run clean:log",
     "lint": "eslint --ext .js src test/unit test/e2e",
     "test:unit": "QT_QPA_PLATFORM='' ./node_modules/karma/bin/karma start karma.conf.js --single-run",
+    "test:unitp": "QT_QPA_PLATFORM='' ./node_modules/karma/bin/karma start karma.conf.js --single-run --browsers PhantomJS",
+    "test:unitf": "QT_QPA_PLATFORM='' ./node_modules/karma/bin/karma start karma.conf.js --single-run --browsers Firefox",
+    "test:unitc": "QT_QPA_PLATFORM='' ./node_modules/karma/bin/karma start karma.conf.js --single-run --browsers Chrome",
     "test:e2e": "node test/e2e/runner.js",
     "test": "npm run test:unit && npm run test:e2e"
   },


### PR DESCRIPTION
With `npm run test:unitp`, you run the unit tests only in PhantomJS.
With `npm run test:unitc`, you run the unit tests only in Chrome.
With `npm run test:unitf`, you run the unit tests only in Firefox.