### PR TITLE
Fix issue #330 The `negativePositiveSignPlacement` option can be ignored in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Change log for autoNumeric:
 
+### "2.0.0-beta.18"
++ Fix issue #330 The `negativePositiveSignPlacement` option can be ignored in some cases         
+
 ### "2.0.0-beta.17"
 + Fix issue #317 allow jumping over the decimal character when the caret is just left of the decimal character and the user enters the decimal character
 + Fix issue #319 so the 'get' method returns a negative value when there is a trailing negative sign.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autonumeric",
-  "version": "2.0.0-beta.17",
+  "version": "2.0.0-beta.18",
   "description": "autoNumeric is a jQuery plugin that automatically formats currency (money) and numbers as you type on form inputs. It supports most international numeric formats and currency signs including those used in Europe, North and South America, Asia and India's' lakhs.",
   "main": "src/autoNumeric.js",
   "typings": "typings.d.ts",


### PR DESCRIPTION
Rewrite some options description to make them more clear.
Change the option `negativePositiveSignPlacement` default value from `'l'` to `null`.
Make sure that `get` never pad the decimal places with zeros.
Simplify `correctPNegOption()` to use only one parameter for the settings object.
Rename `correctPNegOption()` to `correctNegativePositiveSignPlacementOption()`.
Rename `correctMDecOption()` to `correctDecimalPlacesOverrideOption()`