### PR TITLE
Fix issue #346 Add a `showPositiveSign` option to display the positive sign wherever needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Change log for autoNumeric:
 
+### "2.0.0-beta.21"
++ Fix issue #346 Add a `showPositiveSign` option to display the positive sign wherever needed
+
 ### "2.0.0-beta.20"
 + Fix issue #341 Add some default options in the `languageOption` object
 + Fix issue #328 Switch from `npm` to `yarn`

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Multiple options allow you to customize precisely how a form input will format y
 | `currencySymbol` | Currency symbol | `''` |
 | `currencySymbolPlacement` | Placement of the currency sign, relative to the number (as a prefix or a suffix) | `'p'` |
 | `negativePositiveSignPlacement` | Placement of negative/positive sign relative to the currency symbol (possible options are `l` (left), `r` (right), `p` (prefix) and `s` (suffix)) | `null` |
+| `showPositiveSign` | Allow the positive sign symbol `+` to be displayed for positive numbers | `false` |
 | `suffixText` | Additional text suffix that is added after the number | `''` |
 | `overrideMinMaxLimits` | Override minimum and maximum limits (possible options are `ceiling`, `floor` and `ignore`) | `null` |
 | `maximumValue` | Maximum possible value | `'9999999999999.99'` |
@@ -204,6 +205,8 @@ First things first, in order to be able to compile the ES6 source to something t
 ```sh
 yarn install
 ```
+
+*Note: you need to have `yarn` installed before doing this command.<br>You can install `yarn` globally by doing `npm install -g yarn` as root.*
 
 Once you made your changes, you can build the library with :
 ```sh

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autonumeric",
-  "version": "2.0.0-beta.20",
+  "version": "2.0.0-beta.21",
   "description": "autoNumeric is a jQuery plugin that automatically formats currency (money) and numbers as you type on form inputs. It supports most international numeric formats and currency signs including those used in Europe, North and South America, Asia and India's' lakhs.",
   "main": "src/autoNumeric.js",
   "readmeFilename": "README.MD",
@@ -61,7 +61,7 @@
     "build": "yarn run clean:build && yarn run build:dev && yarn run build:prd",
     "clean:build": "rimraf dist",
     "clean:coverage": "rimraf test/unit/coverage",
-    "clean:log": "rimraf yarn-debug.log",
+    "clean:log": "rimraf npm-debug.log selenium-debug.log",
     "clean": "yarn run clean:build && yarn run clean:coverage && yarn run clean:log",
     "lint": "eslint --ext .js src test/unit test/e2e",
     "test:unit": "QT_QPA_PLATFORM='' ./node_modules/karma/bin/karma start karma.conf.js --single-run",

--- a/test/unit/autoNumeric.spec.js
+++ b/test/unit/autoNumeric.spec.js
@@ -95,6 +95,7 @@ describe('The autoNumeric object', () => {
         currencySymbol               : '',
         currencySymbolPlacement      : 'p',
         negativePositiveSignPlacement: null,
+        showPositiveSign             : false,
         suffixText                   : '',
         overrideMinMaxLimits         : null,
         maximumValue                 : '9999999999999.99',
@@ -312,6 +313,30 @@ describe('The autoNumeric object', () => {
             expect(aNInputSettings.currencySymbol).toEqual('$');
             expect(aNInputSettings.currencySymbolPlacement).toEqual('p');
             expect(aNInputSettings.negativePositiveSignPlacement).toEqual('l');
+        });
+
+        it(`this should not override the negativePositiveSignPlacement value 'p' if it has been set by the user`, () => {
+            aNInput = $(newInput).autoNumeric('init', { negativePositiveSignPlacement : 'p' }); // Initiate the autoNumeric input
+            const aNInputSettings = aNInput.autoNumeric('getSettings');
+            expect(aNInputSettings.negativePositiveSignPlacement).toEqual('p');
+        });
+
+        it(`this should not override the negativePositiveSignPlacement value 's' if it has been set by the user`, () => {
+            aNInput = $(newInput).autoNumeric('init', { negativePositiveSignPlacement : 's' }); // Initiate the autoNumeric input
+            const aNInputSettings = aNInput.autoNumeric('getSettings');
+            expect(aNInputSettings.negativePositiveSignPlacement).toEqual('s');
+        });
+
+        it(`this should not override the negativePositiveSignPlacement value 'l' if it has been set by the user`, () => {
+            aNInput = $(newInput).autoNumeric('init', { negativePositiveSignPlacement : 'l' }); // Initiate the autoNumeric input
+            const aNInputSettings = aNInput.autoNumeric('getSettings');
+            expect(aNInputSettings.negativePositiveSignPlacement).toEqual('l');
+        });
+
+        it(`this should not override the negativePositiveSignPlacement value 'r' if it has been set by the user`, () => {
+            aNInput = $(newInput).autoNumeric('init', { negativePositiveSignPlacement : 'r' }); // Initiate the autoNumeric input
+            const aNInputSettings = aNInput.autoNumeric('getSettings');
+            expect(aNInputSettings.negativePositiveSignPlacement).toEqual('r');
         });
     });
 
@@ -679,6 +704,149 @@ describe(`autoNumeric 'init' method`, () => {
 
         aNInput.autoNumeric('update', autoNumericOptionsDollar);
         expect(aNInput.autoNumeric('getFormatted')).toEqual('$256,789.02');
+    });
+
+    // Test the showPositiveSign option
+    // +1.234,00
+    const noneLeft = {
+        digitGroupSeparator        : '.',
+        decimalCharacter           : ',',
+        decimalCharacterAlternative: '.',
+        showPositiveSign           : true,
+    };
+
+    // 1.234,00+
+    const noneSuffix = {
+        digitGroupSeparator          : '.',
+        decimalCharacter             : ',',
+        decimalCharacterAlternative  : '.',
+        negativePositiveSignPlacement: 's',
+        showPositiveSign             : true,
+    };
+
+    // € +1.234,00
+    const leftRight = {
+        digitGroupSeparator          : '.',
+        decimalCharacter             : ',',
+        decimalCharacterAlternative  : '.',
+        currencySymbol               : '€\u00a0',
+        roundingMethod               : 'U',
+        negativePositiveSignPlacement: 'r',
+        showPositiveSign             : true,
+    };
+
+    // +€ 1.234,00
+    const leftLeft = {
+        digitGroupSeparator          : '.',
+        decimalCharacter             : ',',
+        decimalCharacterAlternative  : '.',
+        currencySymbol               : '€\u00a0',
+        roundingMethod               : 'U',
+        negativePositiveSignPlacement: 'l',
+        showPositiveSign             : true,
+    };
+
+    // € 1.234,00+
+    const leftSuffix = {
+        digitGroupSeparator          : '.',
+        decimalCharacter             : ',',
+        decimalCharacterAlternative  : '.',
+        currencySymbol               : '€\u00a0',
+        roundingMethod               : 'U',
+        negativePositiveSignPlacement: 's',
+        showPositiveSign             : true,
+    };
+
+    // 1.234,00+ €
+    const rightLeft = {
+        digitGroupSeparator          : '.',
+        decimalCharacter             : ',',
+        decimalCharacterAlternative  : '.',
+        currencySymbol               : '\u00a0€',
+        currencySymbolPlacement      : 's',
+        roundingMethod               : 'U',
+        negativePositiveSignPlacement: 'l',
+        showPositiveSign             : true,
+    };
+
+    // 1.234,00 €+
+    const rightRight = {
+        digitGroupSeparator          : '.',
+        decimalCharacter             : ',',
+        decimalCharacterAlternative  : '.',
+        currencySymbol               : '\u00a0€',
+        currencySymbolPlacement      : 's',
+        roundingMethod               : 'U',
+        negativePositiveSignPlacement: 'r',
+        showPositiveSign             : true,
+    };
+
+    // +1.234,00 €
+    const rightPrefix = {
+        digitGroupSeparator          : '.',
+        decimalCharacter             : ',',
+        decimalCharacterAlternative  : '.',
+        currencySymbol               : '\u00a0€',
+        currencySymbolPlacement      : 's',
+        roundingMethod               : 'U',
+        negativePositiveSignPlacement: 'p',
+        showPositiveSign             : true,
+    };
+
+    it('should format with showPositiveSign, no currency sign, default placement', () => {
+        newInput.value = '1234567.89';
+        aNInput = $(newInput).autoNumeric('init', noneLeft);
+        expect(aNInput.autoNumeric('get')).toEqual('1234567.89');
+        expect(aNInput.autoNumeric('getFormatted')).toEqual('+1.234.567,89');
+    });
+
+    it('should format with showPositiveSign, no currency sign, suffix placement', () => {
+        newInput.value = '1234567.89';
+        aNInput = $(newInput).autoNumeric('init', noneSuffix);
+        expect(aNInput.autoNumeric('get')).toEqual('1234567.89');
+        expect(aNInput.autoNumeric('getFormatted')).toEqual('1.234.567,89+');
+    });
+
+    it('should format with showPositiveSign, left currency sign, right placement', () => {
+        newInput.value = '1234567.89';
+        aNInput = $(newInput).autoNumeric('init', leftRight);
+        expect(aNInput.autoNumeric('get')).toEqual('1234567.89');
+        expect(aNInput.autoNumeric('getFormatted')).toEqual('€\u00a0+1.234.567,89');
+    });
+
+    it('should format with showPositiveSign, left currency sign, left placement', () => {
+        newInput.value = '1234567.89';
+        aNInput = $(newInput).autoNumeric('init', leftLeft);
+        expect(aNInput.autoNumeric('get')).toEqual('1234567.89');
+        expect(aNInput.autoNumeric('getFormatted')).toEqual('+€\u00a01.234.567,89');
+    });
+
+    it('should format with showPositiveSign, left currency sign, suffix placement', () => {
+        newInput.value = '1234567.89';
+        aNInput = $(newInput).autoNumeric('init', leftSuffix);
+        expect(aNInput.autoNumeric('get')).toEqual('1234567.89');
+        expect(aNInput.autoNumeric('getFormatted')).toEqual('€\u00a01.234.567,89+');
+    });
+
+    it('should format with showPositiveSign, right currency sign, left placement', () => {
+        newInput.value = '1234567.89';
+        aNInput = $(newInput).autoNumeric('init', rightLeft);
+        expect(aNInput.autoNumeric('get')).toEqual('1234567.89');
+        expect(aNInput.autoNumeric('getFormatted')).toEqual('1.234.567,89+\u00a0€');
+    });
+
+    it('should format with showPositiveSign, right currency sign, right placement', () => {
+        newInput.value = '1234567.89';
+        aNInput = $(newInput).autoNumeric('init', rightRight);
+        expect(aNInput.autoNumeric('get')).toEqual('1234567.89');
+        expect(aNInput.autoNumeric('getFormatted')).toEqual('1.234.567,89\u00a0€+');
+    });
+
+    it('should format with showPositiveSign, right currency sign, prefix placement', () => {
+        newInput.value = '1234567.89';
+        aNInput = $(newInput).autoNumeric('init', rightPrefix);
+        expect(aNInput.autoNumeric('get')).toEqual('1234567.89');
+        expect(aNInput.autoNumeric('getFormatted')).toEqual('+1.234.567,89\u00a0€');
     });
 });
 
@@ -1317,6 +1485,11 @@ describe('Static autoNumeric functions', () => {
             expect(() => an.validate({ negativePositiveSignPlacement: 'r' })).not.toThrow();
             expect(() => an.validate({ negativePositiveSignPlacement: null })).not.toThrow();
 
+            expect(() => an.validate({ showPositiveSign: true })).not.toThrow();
+            expect(() => an.validate({ showPositiveSign: false })).not.toThrow();
+            expect(() => an.validate({ showPositiveSign: 'true' })).not.toThrow();
+            expect(() => an.validate({ showPositiveSign: 'false' })).not.toThrow();
+
             expect(() => an.validate({ suffixText: '' })).not.toThrow();
             expect(() => an.validate({ suffixText: 'foobar' })).not.toThrow();
             expect(() => an.validate({ suffixText: ' foobar' })).not.toThrow();
@@ -1534,6 +1707,12 @@ describe('Static autoNumeric functions', () => {
             expect(() => an.validate({ negativePositiveSignPlacement: 42 })).toThrow();
             expect(() => an.validate({ negativePositiveSignPlacement: true })).toThrow();
             expect(() => an.validate({ negativePositiveSignPlacement: 'foobar' })).toThrow();
+
+            expect(() => an.validate({ showPositiveSign: 0 })).toThrow();
+            expect(() => an.validate({ showPositiveSign: 1 })).toThrow();
+            expect(() => an.validate({ showPositiveSign: '0' })).toThrow();
+            expect(() => an.validate({ showPositiveSign: '1' })).toThrow();
+            expect(() => an.validate({ showPositiveSign: 'foobar' })).toThrow();
 
             expect(() => an.validate({ suffixText: '-foobar' })).toThrow();
             expect(() => an.validate({ suffixText: 'foo-bar' })).toThrow();


### PR DESCRIPTION
Upgrade `isNegative()` so that it can search for a negative sign anywhere in the value.
Add `isZeroOrHasNoValue()` to check if a numeric string represent a value of zero, or is just empty.
Fix `correctNegativePositiveSignPlacementOption()` so that it does not overwrite the `negativePositiveSignPlacement` option if it has been set by the user.
Removes an unnecessary ternary operator.
Fix the bug when trying to unformat a negative value that has a the negative sign not positioned on the far left.
Create a `isNegativeStrict()` function that test if a numeric string has a negative sign on its very first character.
Use `isNegative()` and `isNegativeStrict()` everywhere where the same test was made.