### PR TITLE
Fix issue #310 Setup Webdriver.io for end-to-end (e2e) testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Change log for autoNumeric:
 
+### "2.0.0-beta.25"
++ Fix issue #310 Setup Webdriver.io for end-to-end (e2e) testing
+
 ### "2.0.0-beta.24"
 + Fix issue #326 Pasting a single decimal character into an input that has none does not work
 + Fix issue #322 Pasting a string containing a comma set the caret position at the wrong position

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ yarn test:unitf   # ...with Firefox only
 yarn test:unitc   # ...with Chrome only
 ```
 
-Behind the scene, [Karma](https://github.com/karma-runner/karma) is used to run the unit testing written with [Jasmine](https://jasmine.github.io/), while [webdriver.io](https://github.com/webdriverio/webdriver.io) will [soon](https://github.com/BobKnothe/autoNumeric/issues/310) be available for end-to-end testing.
+Behind the scene, all unit and end-to-end tests are written with [Jasmine](https://jasmine.github.io/).<br>[Karma](https://github.com/karma-runner/karma) is used to run the unit tests, while [Webdriver.io](https://github.com/webdriverio/webdriver.io) is used to run end-to-end tests.
 
 ##### How to lint?
 Linting allow us to keep a coherent code style in all the source files.<br>In order to check that everything is ok, run [eslint](http://eslint.org/) with :

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autonumeric",
-  "version": "2.0.0-beta.24",
+  "version": "2.0.0-beta.25",
   "description": "autoNumeric is a library that provides live *as-you-type* formatting for international numbers and currencies. It supports most International numeric formats and currencies including those used in Europe, Asia, and North and South America.",
   "main": "src/autoNumeric.js",
   "readmeFilename": "README.MD",
@@ -31,6 +31,9 @@
     {
       "name": "Alexandre Bonneau",
       "email": "alexandre.bonneau@linuxfr.eu"
+    },
+    {
+      "name": "Sokolov Yura"
     },
     {
       "name": "Carlos Gonzales"
@@ -81,6 +84,7 @@
     "babel-loader": "latest",
     "babel-plugin-add-module-exports": "latest",
     "babel-preset-latest": "latest",
+    "babel-register": "^6.22.0",
     "coveralls": "^2.11.15",
     "eslint": "latest",
     "imports-loader": "latest",
@@ -97,6 +101,10 @@
     "phantomjs-prebuilt": "latest",
     "rimraf": "latest",
     "uglify-js": "latest",
+    "wdio-jasmine-framework": "^0.2.19",
+    "wdio-selenium-standalone-service": "^0.0.7",
+    "wdio-spec-reporter": "^0.0.5",
+    "webdriverio": "^4.6.1",
     "webpack": "latest"
   },
   "scripts": {
@@ -105,15 +113,16 @@
     "build": "yarn run clean:build && yarn run build:dev && yarn run build:prd",
     "clean:build": "rimraf dist",
     "clean:coverage": "rimraf test/unit/coverage",
-    "clean:log": "rimraf npm-debug.log selenium-debug.log yarn-error.log",
-    "clean": "yarn run clean:build && yarn run clean:coverage && yarn run clean:log",
+    "clean:e2e": "rimraf test/e2e/reports/* && rimraf test/e2e/screenshots/*",
+    "clean:log": "rimraf npm-debug.log selenium-debug.log test/e2e/selenium.log yarn-error.log",
+    "clean": "yarn run clean:build && yarn run clean:coverage && yarn run clean:log && npm run clean:e2e",
     "lint": "eslint --ext .js src test/unit test/e2e",
+    "test": "yarn run test:unit && yarn run test:e2e",
     "test:unit": "QT_QPA_PLATFORM='' ./node_modules/karma/bin/karma start karma.conf.js --single-run",
     "test:unitp": "QT_QPA_PLATFORM='' ./node_modules/karma/bin/karma start karma.conf.js --single-run --browsers PhantomJS",
     "test:unitf": "QT_QPA_PLATFORM='' ./node_modules/karma/bin/karma start karma.conf.js --single-run --browsers Firefox",
     "test:unitc": "QT_QPA_PLATFORM='' ./node_modules/karma/bin/karma start karma.conf.js --single-run --browsers Chrome",
-    "test:e2e": "node test/e2e/runner.js",
-    "test": "yarn run test:unit && yarn run test:e2e",
+    "test:e2e": "wdio test/e2e/wdio.local.conf.js",
     "travis:test": "yarn run test:unitp",
     "travis:lint": "yarn run lint"
   },

--- a/test/e2e/index.html
+++ b/test/e2e/index.html
@@ -1,0 +1,710 @@
+<!--
+ * @author Alexandre Bonneau <alexandre.bonneau@linuxfr.eu>
+ * @copyright © 2017 Alexandre Bonneau
+ *
+ * The MIT License (http://www.opensource.org/licenses/mit-license.php)
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sub license, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8"/>
+	<title>End-to-end testing for autoNumeric</title>
+	<style>
+		.container {
+			height          : 100vh;
+			display         : flex;
+			justify-content : flex-start;
+			align-items     : center;
+			flex-direction  : column;
+		}
+
+		.testSuite {
+			border     : 1px solid #057905;
+			margin-top : 2rem;
+			padding    : 0.2rem 0.3rem;
+			transition : border 0.3s ease;
+		}
+
+		.testSuite:hover {
+			border : 1px solid lime;
+		}
+
+		.testSuite:hover p.description {
+			color : lime;
+		}
+
+		.test {
+			display : flex;
+		}
+
+		p.description {
+			color      : #EEE;
+			transition : color 0.3s ease;
+		}
+
+		input[type="text"] {
+			text-align       : right;
+			border-radius    : 2px;
+			border           : 1px solid #5F5F5F;
+			background-color : #3E3E3E;
+			font-size        : 1rem;
+			color            : #D4D4D4;
+			padding          : 0.2rem;
+			margin-top       : 0.1rem;
+			margin-bottom    : 0.1rem;
+			transition       : border 0.3s ease;
+			outline          : none;
+		}
+
+		input[type="text"]::-webkit-input-placeholder {
+			color : #737373;
+		}
+
+		input[type="text"]:hover {
+			border : 1px solid #70A0A5;
+		}
+
+		input[type="text"]:focus {
+			border : 1px solid #00B3C5;
+		}
+
+		body {
+			background : #333;
+			color      : #EEE;
+		}
+
+		p {
+			margin        : 0;
+			padding-left  : 0.3rem;
+			padding-right : 0.3rem;
+		}
+
+		a {
+			color           : #EEE;
+			text-decoration : none;
+		}
+
+		a:hover {
+			color           : lime;
+			text-decoration : underline;
+		}
+	</style>
+	<script src="../../node_modules/jquery/dist/jquery.min.js"></script>
+	<script src="../../dist/autoNumeric.min.js"></script>
+</head>
+<body>
+<div class="container">
+	<div class="title">End-to-end testing page for <a href="https://github.com/BobKnothe/autoNumeric" target="_blank">autoNumeric</a></div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Classic input that throws events</p>
+			<form class="classic">
+				<input id="classic" type="text" placeholder="classic input" value="987654321">
+			</form>
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #292 : Native events</p>
+			<form autocomplete="off">
+				<input class="jqueryManagedInput" type="text" placeholder="via jQuery" name="foo" id="bar">
+				<input class="pureJsManagedInput" type="text" placeholder="via Pure JS" name="quu" id="quux">
+			</form>
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #283</p>
+			<div class="issue_283">
+				<div>
+					<input id="issue283Input0" type="text" placeholder="leadingZero : 'allow'">
+					<input id="issue283Input1" type="text" placeholder="leadingZero : 'deny'">
+					<input id="issue283Input2" type="text" placeholder="leadingZero : 'deny'">
+				</div>
+				<div>
+					<input id="issue283Input3" type="text" placeholder="leadingZero : 'allow'">
+					<input id="issue283Input4" type="text" placeholder="leadingZero : 'deny'">
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #295</p>
+			<div>
+				<div>1. Field : <input type="text" id="firstField"></div>
+				<div>2. Field : <input type="text" id="secondField"></div>
+			</div>
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #290</p>
+			<div class="issue_290">
+				<input type="text" placeholder="#290">
+			</div>
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #291</p>
+			<input id="issue_291" type="text" placeholder="#291">
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #183</p>
+			<div>
+				<input id="issue_183_error" type="text" placeholder="#183 - onInvalidPaste error" value="12345678">
+				<input id="issue_183_ignore" type="text" placeholder="#183 - onInvalidPaste ignore" value="12345678">
+				<input id="issue_183_clamp" type="text" placeholder="#183 - onInvalidPaste clamp" value="12345678">
+				<input id="issue_183_truncate" type="text" placeholder="#183 - onInvalidPaste truncate" value="12345678">
+				<input id="issue_183_replace" type="text" placeholder="#183 - onInvalidPaste replace" value="12345678">
+			</div>
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #302</p>
+			<input id="issue_302" type="text" placeholder="#302">
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #226</p>
+			<input id="issue_226" type="text" placeholder="#226">
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #187</p>
+			<input id="issue_187" type="text" placeholder="#187">
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #193</p>
+			<input id="issue_193" type="text" placeholder="#193">
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #306</p>
+			<div>
+				<input id="issue_306" type="text" placeholder="#306">
+				<input id="issue_306decimals" type="text" placeholder="#306">
+				<input id="issue_306decimals2" type="text" placeholder="#306">
+			</div>
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #262</p>
+			<input id="issue_262" type="text" placeholder="#262">
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #321</p>
+			<div>
+				<div>
+					<input id="issue_321_a" type="text" placeholder="#321">
+					<input id="issue_321_b" type="text" placeholder="#321">
+					<input id="issue_321_c" type="text" placeholder="#321">
+				</div>
+				<div>
+					<input id="issue_321_d" type="text" placeholder="#321">
+					<input id="issue_321_e" type="text" placeholder="#321">
+				</div>
+				<div>
+					<input id="issue_321_f" type="text" placeholder="#321">
+					<input id="issue_321_g" type="text" placeholder="#321" value="١٢٣٤٥٠٦٧٫٨٩">
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #319</p>
+			<input id="issue_319" type="text" placeholder="#319">
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #346</p>
+			<div>
+				<div>
+					<input id="issue_346_1" type="text" placeholder="#346" value="0">
+					<input id="issue_346_2" type="text" placeholder="#346" value="0">
+					<input id="issue_346_3" type="text" placeholder="#346" value="1234.567">
+				</div>
+				<div>
+					<input id="issue_346_4" type="text" placeholder="#346" value="1234.567">
+					<input id="issue_346_5" type="text" placeholder="#346" value="1234.567">
+					<input id="issue_346_6" type="text" placeholder="#346" value="1234.567">
+				</div>
+				<div>
+					<input id="issue_346_7" type="text" placeholder="#346" value="1234.567">
+					<input id="issue_346_8" type="text" placeholder="#346" value="1234.567">
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #326</p>
+			<input id="issue_326" type="text" placeholder="#326" value="12345678">
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #322</p>
+			<input id="issue_322" type="text" placeholder="#322" value="12345678">
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #250</p>
+			<input id="issue_250" type="text" placeholder="#250">
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #317</p>
+			<input id="issue_317" type="text" placeholder="#317" value="0">
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #303</p>
+			<div>
+				<input id="issue_303non_an" type="text" placeholder="#303">
+				<input id="issue_303p" type="text" placeholder="#303" value="">
+				<input id="issue_303s" type="text" placeholder="#303" value="">
+			</div>
+		</div>
+	</div>
+</div>
+<script>
+    //Current master : https://cdn.rawgit.com/BobKnothe/autoNumeric/master/dist/autoNumeric.min.js
+
+    //-------------- Classic input
+    const classicInput = document.querySelector('#classic');
+    classicInput.addEventListener('keydown', () => { console.warn('-- Classic "keydown" thrown'); }, false);
+    classicInput.addEventListener('keypress', () => { console.warn('Classic "keypress" thrown'); }, false);
+    classicInput.addEventListener('input', () => { console.warn('Classic "Input" thrown'); }, false);
+    classicInput.addEventListener('keyup', () => { console.warn('Classic "keyup" thrown'); }, false);
+    classicInput.addEventListener('blur', () => { console.warn('Classic "blur" thrown'); }, false);
+    classicInput.addEventListener('change', () => { console.warn('Classic "change" thrown'); }, false);
+    document.querySelector('form.classic').addEventListener('submit', (e) => {
+        console.warn('Classic "submit" thrown');
+        e.preventDefault();
+    }, false);
+
+    //-------------- Native input/change event not being thrown correctly (initially)
+    const jQueryInput = $('.jqueryManagedInput');
+    const pureJsInput = document.querySelector('.pureJsManagedInput');
+    const $pureJsInput = $(pureJsInput);
+
+    //    jQueryInput.autoNumeric('init', {decimalCharacter: ',', digitGroupSeparator: '.'}); //Basic
+    //    $pureJsInput.autoNumeric('init', {decimalCharacter: ',', digitGroupSeparator: '.'}); //Basic
+
+    jQueryInput.autoNumeric('init', { digitGroupSeparator: '.', decimalCharacter: ',', decimalCharacterAlternative: '.', currencySymbol: ' €', currencySymbolPlacement: 's', roundingMethod: 'U', minimumValue: '0', selectNumberOnly: true }); //Euro positive
+    $pureJsInput.autoNumeric('init', { digitGroupSeparator: '.', decimalCharacter: ',', decimalCharacterAlternative: '.', currencySymbol: ' €', currencySymbolPlacement: 's', roundingMethod: 'U', minimumValue: '0', selectNumberOnly: true }); //Euro positive
+
+    //    jQueryInput.autoNumeric('init', {digitGroupSeparator: '.', decimalCharacter: ',', decimalCharacterAlternative: '.', currencySymbol: ' €', currencySymbolPlacement: 's', roundingMethod: 'U', minimumValue: '-9999999999.99', maximumValue: '0', negativePositiveSignPlacement: 'p'}); //Euro negative
+    //    $pureJsInput.autoNumeric('init', {digitGroupSeparator: '.', decimalCharacter: ',', decimalCharacterAlternative: '.', currencySymbol: ' €', currencySymbolPlacement: 's', roundingMethod: 'U', minimumValue: '-9999999999.99', maximumValue: '0', negativePositiveSignPlacement: 'p'}); //Euro negative
+
+    // jQuery version
+    jQueryInput.on('input', () => {
+        console.warn('#### jQuery "Input" thrown', jQueryInput.autoNumeric('get'));
+    });
+
+    jQueryInput.on('change', () => {
+        console.warn('#### jQuery "Change" thrown', jQueryInput.autoNumeric('get'));
+    });
+
+    // Pure JS
+    pureJsInput.addEventListener('input', (e) => {
+        console.warn('>>> Pure "Input" thrown', $pureJsInput.autoNumeric('get'));
+    }, false);
+    pureJsInput.addEventListener('change', (e) => {
+        console.warn('>>> Pure "Change" thrown', $pureJsInput.autoNumeric('get'));
+    }, false);
+
+    //-------------- Issue #283
+    const issue283Input0 = $('#issue283Input0');
+    issue283Input0.autoNumeric('init', { leadingZero: 'allow' });
+    issue283Input0.autoNumeric('set', 1.12345);
+
+    const issue283Input1 = $('#issue283Input1');
+    issue283Input1.autoNumeric('init', { leadingZero: 'deny', maximumValue: '99999999.9999' });
+    issue283Input1.autoNumeric('set', 1.12345);
+
+    const issue283Input2 = $('#issue283Input2');
+    issue283Input2.autoNumeric('init', { digitGroupSeparator: ' ', decimalCharacter: ',', decimalCharacterAlternative: '.', currencySymbol: '%', currencySymbolPlacement: 's', roundingMethod: 'U', decimalPlacesOverride: '3', leadingZero: 'deny' });
+    issue283Input2.autoNumeric('set', 1.12345);
+
+    const issue283Input3 = $('#issue283Input3');
+    issue283Input3.autoNumeric('init', { digitGroupSeparator: '.', decimalCharacter: ',', decimalCharacterAlternative: '.', currencySymbol: '\u00a0€', currencySymbolPlacement: 's', roundingMethod: 'U', minimumValue: '0', leadingZero: 'allow' });
+    issue283Input3.autoNumeric('set', 8000);
+    const pureIssue283Input3 = document.querySelector('#issue283Input3');
+    pureIssue283Input3.addEventListener('focus', (e) => { console.warn('issue283Input3 focus detected', e.keyCode); }, false);
+    pureIssue283Input3.addEventListener('keydown', (e) => { console.warn('issue283Input3 keydown detected', e.keyCode); }, false);
+    pureIssue283Input3.addEventListener('keypress', (e) => { console.warn('issue283Input3 keypress detected', e.keyCode); }, false);
+    pureIssue283Input3.addEventListener('input', (e) => { console.warn('issue283Input3 input detected', e.keyCode); }, false);
+    pureIssue283Input3.addEventListener('keyup', (e) => { console.warn('issue283Input3 keyup detected', e.keyCode); }, false);
+    pureIssue283Input3.addEventListener('change', (e) => { console.warn('issue283Input3 change detected', e.keyCode); }, false);
+    pureIssue283Input3.addEventListener('blur', (e) => { console.warn('issue283Input3 blur detected', e.keyCode); }, false);
+
+    const issue283Input4 = $('#issue283Input4');
+    issue283Input4.autoNumeric('init', { digitGroupSeparator: '.', decimalCharacter: ',', decimalCharacterAlternative: '.', currencySymbol: '\u00a0€', currencySymbolPlacement: 's', roundingMethod: 'U', minimumValue: '0', leadingZero: 'deny' });
+    issue283Input4.autoNumeric('set', 8000);
+
+    //-------------- Issue #295
+    var priceFormatOptions = { decimalPlacesOverride: '2', maximumValue: '999999999999.99', digitGroupSeparator: ',', decimalCharacter: '.' };
+
+    $('#firstField, #secondField').autoNumeric('init', priceFormatOptions);
+
+    $("#firstField").on("keyup", function() {
+        var value = $(this).val();
+        $('#secondField').val(value);
+//        $('#firstField, #secondField').autoNumeric('update', priceFormatOptions);
+    });
+
+    //-------------- Issue #290
+    const issue290Input = $(document.querySelector('.issue_290 input'));
+    issue290Input.autoNumeric('init', {
+        digitGroupSeparator        : '.',
+        decimalCharacter           : ',',
+        decimalCharacterAlternative: '.',
+        currencySymbol             : '\u00a0€',
+        currencySymbolPlacement    : 's',
+        roundingMethod             : 'U',
+        leadingZero                : 'deny',
+        minimumValue               : '0.00',
+        maximumValue               : '999999999999.99'
+    });
+
+    //-------------- Issue #291
+    const issue291Input = $(document.querySelector('#issue_291'));
+    issue291Input.autoNumeric('init', {
+        digitGroupSeparator        : '.',
+        decimalCharacter           : ',',
+        decimalCharacterAlternative: '.',
+        currencySymbol             : '\u00a0€',
+        currencySymbolPlacement    : 's',
+        roundingMethod             : 'U',
+        leadingZero                : 'deny',
+        minimumValue               : '0.00',
+        maximumValue               : '999999999999.99'
+    });
+
+    //-------------- Issue #183
+    const issue183InputError = $(document.querySelector('#issue_183_error'));
+    issue183InputError.autoNumeric('init', {
+        digitGroupSeparator        : '.',
+        decimalCharacter           : ',',
+        decimalCharacterAlternative: '.',
+        currencySymbol             : '\u00a0€',
+        currencySymbolPlacement    : 's',
+        roundingMethod             : 'U',
+        leadingZero                : 'deny',
+        minimumValue               : '-999999999999.99',
+        maximumValue               : '999999999999.99',
+        onInvalidPaste             : 'error',
+        negativeBracketsTypeOnBlur : '(,)',
+        decimalPlacesShownOnFocus  : 5
+    });
+    const issue183InputIgnore = $(document.querySelector('#issue_183_ignore'));
+    issue183InputIgnore.autoNumeric('init', {
+        digitGroupSeparator        : '.',
+        decimalCharacter           : ',',
+        decimalCharacterAlternative: '.',
+        currencySymbol             : '\u00a0€',
+        currencySymbolPlacement    : 's',
+        roundingMethod             : 'U',
+        leadingZero                : 'deny',
+        minimumValue               : '-999999999999.99',
+        maximumValue               : '999999999999.99',
+        onInvalidPaste             : 'ignore'
+    });
+    const issue183InputClamp = $(document.querySelector('#issue_183_clamp'));
+    issue183InputClamp.autoNumeric('init', {
+        digitGroupSeparator        : '.',
+        decimalCharacter           : ',',
+        decimalCharacterAlternative: '.',
+        currencySymbol             : '$ ',
+        currencySymbolPlacement    : 'p',
+        roundingMethod             : 'U',
+        leadingZero                : 'deny',
+        minimumValue               : '-999999999999.99',
+        maximumValue               : '999999999999.99',
+        onInvalidPaste             : 'clamp'
+    });
+    const issue183InputTruncate = $(document.querySelector('#issue_183_truncate'));
+    issue183InputTruncate.autoNumeric('init', {
+        digitGroupSeparator        : '.',
+        decimalCharacter           : ',',
+        decimalCharacterAlternative: '.',
+        currencySymbol             : '\u00a0€',
+        currencySymbolPlacement    : 's',
+        roundingMethod             : 'U',
+        leadingZero                : 'deny',
+        minimumValue               : '-999999999999.99',
+        maximumValue               : '999999999999.99',
+        onInvalidPaste             : 'truncate'
+    });
+    const issue183InputReplace = $(document.querySelector('#issue_183_replace'));
+    issue183InputReplace.autoNumeric('init', {
+        digitGroupSeparator        : '.',
+        decimalCharacter           : ',',
+        decimalCharacterAlternative: '.',
+        currencySymbol             : '\u00a0€',
+        currencySymbolPlacement    : 's',
+        roundingMethod             : 'U',
+        leadingZero                : 'deny',
+        minimumValue               : '-999999999999.99',
+        maximumValue               : '2999999999911.99',
+        onInvalidPaste             : 'replace'
+    });
+
+    //-------------- Issue #302
+    const issue302Input = $(document.querySelector('#issue_302'));
+    issue302Input.autoNumeric('init', { digitGroupSeparator: '.', decimalCharacter: ',', decimalCharacterAlternative: '.', currencySymbol: '\u00a0€', currencySymbolPlacement: 's', roundingMethod: 'U', minimumValue: '0', leadingZero: 'deny' });
+
+    //-------------- Issue #226
+    const issue226Input = $(document.querySelector('#issue_226'));
+    issue226Input.autoNumeric('init', { allowDecimalPadding: false, formatOnPageLoad: false, minimumValue: '0', leadingZero: 'deny', maximumValue: '2147483647', decimalPlacesOverride: '0' });
+
+    //-------------- Issue #187
+    const issue187input = document.querySelector('#issue_187');
+    const $issue187Input = $(issue187input);
+    $issue187Input.autoNumeric('init');
+    issue187input.addEventListener('autoNumeric:formatted', () => {
+        console.log(`The 'autoNumeric:formatted' event has been caught!`); //DEBUG
+    }, false);
+
+    //-------------- Issue #193
+    const issue193Input = $(document.querySelector('#issue_193'));
+    issue193Input.autoNumeric('init', { digitGroupSeparator: "'", decimalCharacter: ',' });
+
+    //-------------- Issue #306
+    const issue306Input = $(document.querySelector('#issue_306'));
+    issue306Input.autoNumeric('init', { leadingZero: 'deny' });
+    const issue306InputDecimals = $(document.querySelector('#issue_306decimals'));
+    issue306InputDecimals.autoNumeric('init', { leadingZero: 'deny', maximumValue : '999999999.99999', digitGroupSeparator: '.', decimalCharacter: ',' });
+    const issue306InputDecimals2 = $(document.querySelector('#issue_306decimals2'));
+    issue306InputDecimals2.autoNumeric('init', { leadingZero: 'deny', maximumValue : '999999999.99', digitGroupSeparator: '.', decimalCharacter: ',' });
+
+    //-------------- Issue #262
+    const issue262Input = $(document.querySelector('#issue_262'));
+    issue262Input.autoNumeric('init', { leadingZero: 'deny', decimalPlacesOverride:'2', roundingMethod:'D' });
+
+    //-------------- Issue #321
+    $(document.querySelector('#issue_321_a')).autoNumeric('init', { digitGroupSeparator: '٬'     , decimalCharacter: '٫', decimalCharacterAlternative: ',' });
+    $(document.querySelector('#issue_321_b')).autoNumeric('init', { digitGroupSeparator: '\u2009', decimalCharacter: '·', decimalCharacterAlternative: ',' });
+    $(document.querySelector('#issue_321_c')).autoNumeric('init', { digitGroupSeparator: '\u202f', decimalCharacter: '⎖', decimalCharacterAlternative: ',' });
+    $(document.querySelector('#issue_321_d')).autoNumeric('init', { digitGroupSeparator: '\u00a0', decimalCharacter: '.', decimalCharacterAlternative: ',' });
+    $(document.querySelector('#issue_321_e')).autoNumeric('init', { digitGroupSeparator: '˙'     , decimalCharacter: '·', decimalCharacterAlternative: ',' });
+    const issue321Input = $(document.querySelector('#issue_321_f'));
+    $(document.querySelector('#issue_321_f')).autoNumeric('init', { digitGroupSeparator: '٬' , decimalCharacter: '٫', decimalCharacterAlternative: ',' });
+    issue321Input.autoNumeric('set', '١٢٣٤٥٦٧٨٫٩٠'); // ٠١٢٣٤٥٦٧٨٩
+    $(document.querySelector('#issue_321_g')).autoNumeric('init', { digitGroupSeparator: '٬' , decimalCharacter: '٫', decimalCharacterAlternative: ',' });
+
+    //-------------- Issue #319
+    const issue319Input = $(document.querySelector('#issue_319'));
+    issue319Input.autoNumeric('init', { digitGroupSeparator: '.', decimalCharacter: ',', currencySymbol: " €", currencySymbolPlacement: 's', negativePositiveSignPlacement: 'l', emptyInputBehavior: 'zero' });
+
+    //-------------- Issue #346
+    // +1.234,00
+    const noneLeft = {
+        digitGroupSeparator        : '.',
+        decimalCharacter           : ',',
+        decimalCharacterAlternative: '.',
+        showPositiveSign           : true
+    };
+
+    // 1.234,00+
+    const noneSuffix = {
+        digitGroupSeparator          : '.',
+        decimalCharacter             : ',',
+        decimalCharacterAlternative  : '.',
+        negativePositiveSignPlacement: 's',
+        showPositiveSign             : true
+    };
+
+    // € +1.234,00
+    const leftRight = {
+        digitGroupSeparator          : '.',
+        decimalCharacter             : ',',
+        decimalCharacterAlternative  : '.',
+        currencySymbol               : '€\u00a0',
+        roundingMethod               : 'U',
+        negativePositiveSignPlacement: 'r',
+        showPositiveSign             : true
+    };
+
+    // +€ 1.234,00
+    const leftLeft = {
+        digitGroupSeparator          : '.',
+        decimalCharacter             : ',',
+        decimalCharacterAlternative  : '.',
+        currencySymbol               : '€\u00a0',
+        roundingMethod               : 'U',
+        negativePositiveSignPlacement: 'l',
+        showPositiveSign             : true
+    };
+
+    // € 1.234,00+
+    const leftSuffix = {
+        digitGroupSeparator          : '.',
+        decimalCharacter             : ',',
+        decimalCharacterAlternative  : '.',
+        currencySymbol               : '€\u00a0',
+        roundingMethod               : 'U',
+        negativePositiveSignPlacement: 's',
+        showPositiveSign             : true
+    };
+
+    // 1.234,00+ €
+    const rightLeft = {
+        digitGroupSeparator          : '.',
+        decimalCharacter             : ',',
+        decimalCharacterAlternative  : '.',
+        currencySymbol               : '\u00a0€',
+        currencySymbolPlacement      : 's',
+        roundingMethod               : 'U',
+        negativePositiveSignPlacement: 'l',
+        showPositiveSign             : true
+    };
+
+    // 1.234,00 €+
+    const rightRight = {
+        digitGroupSeparator          : '.',
+        decimalCharacter             : ',',
+        decimalCharacterAlternative  : '.',
+        currencySymbol               : '\u00a0€',
+        currencySymbolPlacement      : 's',
+        roundingMethod               : 'U',
+        negativePositiveSignPlacement: 'r',
+        showPositiveSign             : true
+    };
+
+    // +1.234,00 €
+    const rightPrefix = {
+        digitGroupSeparator          : '.',
+        decimalCharacter             : ',',
+        decimalCharacterAlternative  : '.',
+        currencySymbol               : '\u00a0€',
+        currencySymbolPlacement      : 's',
+        roundingMethod               : 'U',
+        negativePositiveSignPlacement: 'p',
+        showPositiveSign             : true
+    };
+
+    const inputIssue346_1 = document.querySelector('#issue_346_1');
+    const inputIssue346_2 = document.querySelector('#issue_346_2');
+    const inputIssue346_3 = document.querySelector('#issue_346_3');
+    const inputIssue346_4 = document.querySelector('#issue_346_4');
+    const inputIssue346_5 = document.querySelector('#issue_346_5');
+    const inputIssue346_6 = document.querySelector('#issue_346_6');
+    const inputIssue346_7 = document.querySelector('#issue_346_7');
+    const inputIssue346_8 = document.querySelector('#issue_346_8');
+
+    $(inputIssue346_1).autoNumeric('init', noneLeft);
+    $(inputIssue346_2).autoNumeric('init', noneSuffix);
+    $(inputIssue346_3).autoNumeric('init', leftRight);
+    $(inputIssue346_4).autoNumeric('init', leftLeft);
+    $(inputIssue346_5).autoNumeric('init', leftSuffix);
+    $(inputIssue346_6).autoNumeric('init', rightLeft);
+    $(inputIssue346_7).autoNumeric('init', rightRight);
+    $(inputIssue346_8).autoNumeric('init', rightPrefix);
+
+    inputIssue346_1.addEventListener('keyup', () => { console.log($(inputIssue346_1).autoNumeric("get"), $(inputIssue346_1).autoNumeric("getSettings").rawValue); }, false);
+    inputIssue346_2.addEventListener('keyup', () => { console.log($(inputIssue346_2).autoNumeric("get"), $(inputIssue346_2).autoNumeric("getSettings").rawValue); }, false);
+    inputIssue346_3.addEventListener('keyup', () => { console.log($(inputIssue346_3).autoNumeric("get"), $(inputIssue346_3).autoNumeric("getSettings").rawValue); }, false);
+    inputIssue346_4.addEventListener('keyup', () => { console.log($(inputIssue346_4).autoNumeric("get"), $(inputIssue346_4).autoNumeric("getSettings").rawValue); }, false);
+    inputIssue346_5.addEventListener('keyup', () => { console.log($(inputIssue346_5).autoNumeric("get"), $(inputIssue346_5).autoNumeric("getSettings").rawValue); }, false);
+    inputIssue346_6.addEventListener('keyup', () => { console.log($(inputIssue346_6).autoNumeric("get"), $(inputIssue346_6).autoNumeric("getSettings").rawValue); }, false);
+    inputIssue346_7.addEventListener('keyup', () => { console.log($(inputIssue346_7).autoNumeric("get"), $(inputIssue346_7).autoNumeric("getSettings").rawValue); }, false);
+    inputIssue346_8.addEventListener('keyup', () => { console.log($(inputIssue346_8).autoNumeric("get"), $(inputIssue346_8).autoNumeric("getSettings").rawValue); }, false);
+
+    //-------------- Issue #326
+    const issue326Input = $(document.querySelector('#issue_326'));
+    issue326Input.autoNumeric('init', {
+        digitGroupSeparator        : '.',
+        decimalCharacter           : ',',
+        decimalCharacterAlternative: '.',
+        currencySymbol             : '\u00a0€',
+        currencySymbolPlacement    : 's',
+        roundingMethod             : 'U',
+        leadingZero                : 'deny',
+        minimumValue               : '-999999999999.99',
+        maximumValue               : '999999999999.99',
+        onInvalidPaste             : 'ignore'
+    });
+
+    //-------------- Issue #322
+    const issue322Input = $(document.querySelector('#issue_322'));
+    issue322Input.autoNumeric('init');
+
+    //-------------- Issue #250
+    const issue250Input = $(document.querySelector('#issue_250'));
+    issue250Input.autoNumeric('init', { decimalPlacesOverride: 2, allowDecimalPadding: false, minimumValue: '2', maximumValue: '999999999' });
+
+    //-------------- Issue #317
+    const issue317Input = $(document.querySelector('#issue_317'));
+    issue317Input.autoNumeric('init', { leadingZero: 'deny', decimalCharacterAlternative: ',' });
+
+    //-------------- Issue #303
+    const issue303AInput = $(document.querySelector('#issue_303p'));
+    issue303AInput.autoNumeric('init', { currencySymbolPlacement: 'p', currencySymbol: '$'      , /*emptyInputBehavior: 'always'*/ });
+    const issue303BInput = $(document.querySelector('#issue_303s'));
+    issue303BInput.autoNumeric('init', { currencySymbolPlacement: 's', currencySymbol: '\u00a0€', /*emptyInputBehavior: 'always'*/ });
+</script>
+</body>
+</html>

--- a/test/e2e/specs/autoNumeric.e2e.spec.js
+++ b/test/e2e/specs/autoNumeric.e2e.spec.js
@@ -1,0 +1,735 @@
+/**
+ * End-to-end tests for autoNumeric.js
+ * @author Alexandre Bonneau <alexandre.bonneau@linuxfr.eu>
+ * @copyright © 2017 Alexandre Bonneau
+ *
+ * The MIT License (http://www.opensource.org/licenses/mit-license.php)
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sub license, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// eslint-disable-next-line
+/* global describe, it, xdescribe, xit, fdescribe, fit, expect, beforeEach, afterEach, spyOn, require, process, browser, $ */
+
+// Note : A list of named keys can be found here : https://github.com/webdriverio/webdriverio/blob/master/lib/helpers/constants.js#L67
+
+
+//-----------------------------------------------------------------------------
+// ---- Configuration
+
+// Generate the index.html file full url
+const directory = require('path');
+const testUrl = `file://${directory.join(process.cwd(), 'test', 'e2e', 'index.html')}`; // Example : 'file:///home/user/taf/_dl/dev/autoNumeric/test/e2e/index.html'
+
+// Object that holds the references to the input we test
+const selectors = {
+    inputClassic          : '#classic',
+    issue283Input0        : '#issue283Input0',
+    issue283Input1        : '#issue283Input1',
+    issue283Input2        : '#issue283Input2',
+    issue283Input3        : '#issue283Input3',
+    issue283Input4        : '#issue283Input4',
+    issue183error         : '#issue_183_error',
+    issue183ignore        : '#issue_183_ignore',
+    issue183clamp         : '#issue_183_clamp',
+    issue183truncate      : '#issue_183_truncate',
+    issue183replace       : '#issue_183_replace',
+    issue326input         : '#issue_326',
+    issue322input         : '#issue_322',
+    issue317input         : '#issue_317',
+    issue306input         : '#issue_306',
+    issue306inputDecimals : '#issue_306decimals',
+    issue306inputDecimals2: '#issue_306decimals2',
+    issue303inputNonAn    : '#issue_303non_an',
+    issue303inputP        : '#issue_303p',
+    issue303inputS        : '#issue_303s',
+};
+
+//-----------------------------------------------------------------------------
+// ---- Helper functions
+
+/*
+function helperGetCaretPosition(wdioElement) { //FIXME Find a way to allow using helper functions inside webdriver.io `execute()` blocks
+    console.log('wdioElement:', wdioElement); //DEBUG 
+    // console.log('this:', this); //DEBUG
+    const selector = wdioElement.selector;
+    console.log('selector:', selector); //DEBUG 
+
+    const element = document.querySelector(selector);
+    console.log('element.selectionStart:', element.selectionStart); //DEBUG 
+    return element.selectionStart;
+}
+*/
+
+
+//-----------------------------------------------------------------------------
+// ---- Tests
+
+xdescribe('webdriver.io page', () => {
+    it('should have the right title - the fancy generator way', () => {
+        browser.url('http://webdriver.io');
+        const title = browser.getTitle();
+        expect(title).toEqual('WebdriverIO - Selenium 2.0 javascript bindings for nodejs');
+    });
+});
+
+describe('webdriver.io runner', () => {
+    it(`should be able to send basic keys to basic inputs (which we'll use later for copy-pasting text strings)`, () => {
+        browser.url(testUrl);
+
+        // Test the initial values
+        const title = browser.getTitle();
+        expect(title).toEqual('End-to-end testing for autoNumeric');
+        expect(browser.getValue(selectors.inputClassic)).toEqual('987654321');
+
+        // Focus in that input
+        const inputClassic = $(selectors.inputClassic);
+        inputClassic.click();
+
+        // Enter some keys
+        browser.keys('End'); // 'chromedriver' does not automatically modify the caret position, so we need to set it up ourselves
+        browser.keys('teststring');
+        expect(browser.getValue(selectors.inputClassic)).toEqual('987654321teststring');
+        // browser.keys('Home'); // This works!
+        browser.keys(['ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft']);
+        browser.keys('YES!');
+        expect(browser.getValue(selectors.inputClassic)).toEqual('987654321teststYES!ring');
+        browser.keys(['ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft']);
+        browser.keys('0');
+        browser.keys('1');
+        expect(browser.getValue(selectors.inputClassic)).toEqual('987654321te01ststYES!ring');
+
+        /*
+        expect(helperGetCaretPosition(inputClassic)).toEqual(42); //FIXME This cannot be called correctly
+        const result = browser.getCaretPosition(inputClassic); //FIXME This cannot be called correctly
+        expect(result).toEqual(19);
+        */
+
+        // Hold some modifier keys
+        browser.keys('End');
+        browser.keys(['ArrowLeft']);
+        browser.keys('Shift'); // This activates the shift key from now on
+        browser.keys([
+            'ArrowLeft',
+            'ArrowLeft',
+            'ArrowLeft',
+            'ArrowLeft',
+            'ArrowLeft',
+            'ArrowLeft',
+            'ArrowLeft',
+            'ArrowLeft',
+            'ArrowLeft',
+            'ArrowLeft',
+            'ArrowLeft',
+            'ArrowLeft',
+            'ArrowLeft',
+            'ArrowLeft',
+            'ArrowLeft',
+            'ArrowLeft',
+            'ArrowLeft',
+            'ArrowLeft',
+        ]);
+        browser.keys('NULL'); // This deactivates any modifiers key (I could have used `browser.keys('Shift');` again to toggle it off)
+        browser.keys('foobar');
+        expect(browser.getValue(selectors.inputClassic)).toEqual('987654foobarg');
+    });
+});
+
+describe('Issue #327 (using inputs from issue #183)', () => {
+    it('should tests for default values', () => {
+        browser.url(testUrl);
+
+        /* eslint space-in-parens: 0 */
+        expect(browser.getValue(selectors.issue183error   )).toEqual('12.345.678,00 €');
+        expect(browser.getValue(selectors.issue183ignore  )).toEqual('12.345.678,00 €');
+        expect(browser.getValue(selectors.issue183clamp   )).toEqual('$ 12.345.678,00');
+        expect(browser.getValue(selectors.issue183truncate)).toEqual('12.345.678,00 €');
+        expect(browser.getValue(selectors.issue183replace )).toEqual('12.345.678,00 €');
+    });
+
+    it(`should show the correct number of decimal places on focus, with 'decimalPlacesShownOnFocus' set to a specific value`, () => {
+        browser.url(testUrl);
+
+        // Focus in that input
+        const input = $(selectors.issue183error);
+        input.click();
+        expect(browser.getValue(selectors.issue183error)).toEqual('12.345.678,00000 €');
+    });
+
+    it(`should get the entire input selected when using the 'tab' key`, () => {
+        browser.url(testUrl);
+
+        // Focus in that first input
+        const input = $(selectors.issue183error);
+        input.click();
+
+        // Then 'tab' on each other inputs
+        browser.keys('Tab');
+        // Check the text selection
+        let inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_183_ignore');
+            return { start: input.selectionStart, end: input.selectionEnd };
+        }).value;
+        expect(inputCaretPosition.start).toEqual(0);
+        expect(inputCaretPosition.end).toEqual(15);
+
+        browser.keys('Tab');
+        // Check the text selection
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_183_clamp');
+            return { start: input.selectionStart, end: input.selectionEnd };
+        }).value;
+        expect(inputCaretPosition.start).toEqual(0);
+        expect(inputCaretPosition.end).toEqual(15);
+
+        browser.keys('Tab');
+        // Check the text selection
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_183_truncate');
+            return { start: input.selectionStart, end: input.selectionEnd };
+        }).value;
+        expect(inputCaretPosition.start).toEqual(0);
+        expect(inputCaretPosition.end).toEqual(15);
+
+        browser.keys('Tab');
+        // Check the text selection
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_183_replace');
+            return { start: input.selectionStart, end: input.selectionEnd };
+        }).value;
+        expect(inputCaretPosition.start).toEqual(0);
+        expect(inputCaretPosition.end).toEqual(15);
+    });
+});
+
+describe('Issue #306', () => {
+    it('should tests for default values', () => {
+        browser.url(testUrl);
+
+        expect(browser.getValue(selectors.issue306input)).toEqual('');
+    });
+
+    it(`should allow entering '0.0'`, () => {
+        // Focus in that input
+        const input = $(selectors.issue306input);
+        input.click();
+
+        // Modify the input value
+        browser.keys('0');
+        expect(browser.getValue(selectors.issue306input)).toEqual('0');
+
+        // Check the caret position
+        let inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_306');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(1);
+
+
+        // Modify the input value
+        browser.keys('Backspace');
+        expect(browser.getValue(selectors.issue306input)).toEqual('');
+        browser.keys('.');
+        expect(browser.getValue(selectors.issue306input)).toEqual('0.');
+
+        // Check the caret position
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_306');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(2);
+
+
+        browser.keys('0');
+        expect(browser.getValue(selectors.issue306input)).toEqual('0.0');
+
+        // Check the caret position
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_306');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(3);
+    });
+
+    it(`should move the caret correctly while in the decimal places`, () => {
+        // Manage the second case
+        // Focus in that input
+        const input = $(selectors.issue306inputDecimals);
+        input.click();
+
+        // Modify the input value
+        expect(browser.getValue(selectors.issue306inputDecimals)).toEqual('');
+        browser.keys('0,00000');
+        expect(browser.getValue(selectors.issue306inputDecimals)).toEqual('0,00000');
+        browser.keys(['Home', 'ArrowRight', '12345']);
+        expect(browser.getValue(selectors.issue306inputDecimals)).toEqual('0,12345');
+        browser.keys(['Home', 'ArrowRight', '00000']);
+        expect(browser.getValue(selectors.issue306inputDecimals)).toEqual('0,00000');
+        let inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_306decimals');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(7);
+
+        // Tests that it does not allow adding a leading 0
+        browser.keys(['Home', '0']);
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_306decimals');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(0);
+
+        // Tests that entering a 0 while in the decimal places moves the caret to the right
+        browser.keys(['ArrowRight', '0']);
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_306decimals');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(3);
+        // ...and another
+        browser.keys('0');
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_306decimals');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(4);
+        // ...and another
+        browser.keys('0');
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_306decimals');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(5);
+        // ...and another
+        browser.keys('0');
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_306decimals');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(6);
+        // ...and another
+        browser.keys('0');
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_306decimals');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(7);
+        // ...and another that should be dropped
+        browser.keys('0');
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_306decimals');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(7);
+    });
+
+    it(`should move the caret correctly while in the decimal places, without having to setup any sequence of inputs`, () => {
+        // Manage the last case
+        // Focus in that input
+        const input = $(selectors.issue306inputDecimals2);
+        input.click();
+
+        // Modify the input value
+        browser.setValue(selectors.issue306inputDecimals2, '50000,00');
+        expect(browser.getValue(selectors.issue306inputDecimals2)).toEqual('50.000,00');
+        browser.keys(['End', 'ArrowLeft', 'ArrowLeft', 'ArrowRight']);
+        let inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_306decimals2');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(7);
+
+        browser.keys('0');
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_306decimals2');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(8);
+
+        browser.keys('0');
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_306decimals2');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(9);
+
+        browser.keys('0');
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_306decimals2');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(9);
+    });
+});
+
+describe('Issue #283', () => {
+    it('should tests for default values', () => {
+        browser.url(testUrl);
+
+        expect(browser.getValue(selectors.issue283Input0)).toEqual('1.12');
+        expect(browser.getValue(selectors.issue283Input1)).toEqual('1.1235');
+        expect(browser.getValue(selectors.issue283Input2)).toEqual('1,124%');
+        expect(browser.getValue(selectors.issue283Input3)).toEqual('8.000,00\u00a0€');
+        expect(browser.getValue(selectors.issue283Input4)).toEqual('8.000,00\u00a0€');
+    });
+
+    it(`should keep the caret position when trying to input a '0' that gets rejected`, () => {
+        browser.url(testUrl);
+
+        // Test the initial value
+        expect(browser.getValue(selectors.issue283Input1)).toEqual('1.1235');
+
+        // Focus in that input
+        const input = $(selectors.issue283Input1);
+        input.click();
+
+        // Change the caret position and modify its value
+        browser.keys(['Home']);
+        browser.keys('0');
+        expect(browser.getValue(selectors.issue283Input1)).toEqual('1.1235');
+
+        // Check the final caret position
+        const inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue283Input1');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(0);
+    });
+
+    it(`should keep the caret position when trying to input a '0' that gets rejected on a euro number`, () => {
+        browser.url(testUrl);
+
+        // Test the initial value
+        expect(browser.getValue(selectors.issue283Input4)).toEqual('8.000,00\u00a0€');
+
+        // Focus in that input
+        const input = $(selectors.issue283Input4);
+        input.click();
+
+        // Change the caret position and modify its value
+        browser.keys(['Home']);
+        browser.keys('0');
+        expect(browser.getValue(selectors.issue283Input4)).toEqual('8.000,00\u00a0€');
+
+        // Check the final caret position
+        const inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue283Input4');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(0);
+    });
+
+    it(`should insert a '0' and move the caret position when leadingZero is 'allow'`, () => {
+        browser.url(testUrl);
+
+        // Test the initial value
+        expect(browser.getValue(selectors.issue283Input3)).toEqual('8.000,00\u00a0€');
+
+        // Focus in that input
+        const input = $(selectors.issue283Input3);
+        input.click();
+
+        // Change the caret position and modify its value
+        browser.keys(['Home']);
+        browser.keys('0');
+        expect(browser.getValue(selectors.issue283Input3)).toEqual('08.000,00\u00a0€');
+
+        // Check the final caret position
+        const inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue283Input3');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(1);
+    });
+
+    it(`should insert a '0' when in the middle of other zeros, and move the caret position`, () => {
+        browser.url(testUrl);
+
+        // Test the initial value
+        expect(browser.getValue(selectors.issue283Input4)).toEqual('8.000,00\u00a0€');
+
+        // Focus in that input
+        const input = $(selectors.issue283Input4);
+        input.click();
+
+        // Change the caret position and modify its value
+        browser.keys(['End', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft']); // 6 left
+        browser.keys('0');
+        expect(browser.getValue(selectors.issue283Input4)).toEqual('80.000,00\u00a0€');
+
+        // Check the final caret position
+        const inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue283Input4');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(4);
+    });
+});
+
+describe('Issue #326', () => {
+    it('should tests for default values, and focus on it', () => {
+        browser.url(testUrl);
+
+        expect(browser.getValue(selectors.issue326input)).toEqual('12.345.678,00 €');
+    });
+
+    it('should position the decimal character correctly on paste', () => {
+        // Add a comma ',' to the classic input in order to be able to copy it with `ctrl+c`
+        const inputClassic = $(selectors.inputClassic);
+        inputClassic.click();
+        browser.keys('End'); // 'chromedriver' does not automatically modify the caret position, so we need to set it up ourselves
+        browser.keys(','); // Note : This does not set, but append the value to the current one
+
+        // Copy ','
+        browser.keys('End');
+        browser.keys('Shift');
+        browser.keys('ArrowLeft');
+        browser.keys('Shift');
+        browser.keys('Control');
+        browser.keys('c');
+        browser.keys('Control');
+        // ',' is copied
+
+        // Remove that ',' in order to get back to the original input state
+        browser.keys('Delete');
+
+        // Focus in the Issue #326 input
+        const input = $(selectors.issue326input);
+        input.click();
+
+        // Delete the ',00 €' part
+        browser.keys('End');
+        browser.keys('Shift');
+        browser.keys(['ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft']);
+        browser.keys('Shift');
+        browser.keys('Delete');
+
+        // Move the caret position to  // 12.34|5.678 €
+        browser.keys(['End', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft']);
+
+        // Paste the comma
+        browser.keys('Control');
+        browser.keys('v');
+        browser.keys('Control');
+
+        // Test the resulting value
+        expect(browser.getValue(selectors.issue326input)).toEqual('1.234,57 €');
+    });
+});
+
+
+describe('Issue #322', () => {
+    it('should tests for default values, and focus on it', () => {
+        browser.url(testUrl);
+
+        expect(browser.getValue(selectors.issue322input)).toEqual('12,345,678.00');
+    });
+
+    it('should paste correctly a string that contains grouping separators when pasting on a caret position', () => {
+        // Add '11,1' to the classic input in order to be able to copy it with `ctrl+c`
+        const inputClassic = $(selectors.inputClassic);
+        inputClassic.click();
+        browser.keys('End'); // 'chromedriver' does not automatically modify the caret position, so we need to set it up ourselves
+        browser.keys('11,1'); // Note : This does not set, but append the value to the current one
+
+        // Copy ','
+        browser.keys('End');
+        browser.keys('Shift');
+        browser.keys(['ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft']);
+        browser.keys('Shift');
+        browser.keys('Control');
+        browser.keys('c');
+        browser.keys('Control');
+        // '11,1' is copied
+
+        // Remove that ',' in order to get back to the original input state
+        browser.keys('Delete');
+
+        // Focus in the issue input
+        const input = $(selectors.issue322input);
+        input.click();
+
+        // Move the caret position to  // 12,345|,678.00
+        browser.keys(['End', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft']);
+
+        // Paste the clipboard content
+        browser.keys('Control');
+        browser.keys('v');
+        browser.keys('Control');
+
+        // Test the resulting value
+        expect(browser.getValue(selectors.issue322input)).toEqual('12,345,111,678.00');
+
+        // Check the caret position
+        const inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_322');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(10);
+    });
+
+    it('should paste correctly a string that contains grouping separators when pasting on a selection', () => {
+        // Pre-requisite : '11,1' is still in the clipboard
+
+        // Focus in the issue input
+        const input = $(selectors.issue322input);
+        input.click();
+
+        // Re-initialize its value
+        browser.setValue(selectors.issue322input, '12345678');
+        expect(browser.getValue(selectors.issue322input)).toEqual('12,345,678');
+
+        // Set the selection to  // 12,|345|,678
+        browser.keys(['End', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft']);
+        browser.keys('Shift');
+        browser.keys(['ArrowLeft', 'ArrowLeft', 'ArrowLeft']);
+        browser.keys('Shift');
+
+        // Paste the clipboard content
+        browser.keys('Control');
+        browser.keys('v');
+        browser.keys('Control');
+
+        // Test the resulting value
+        expect(browser.getValue(selectors.issue322input)).toEqual('12,111,678.00');
+
+        // Check the caret position
+        const inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_322');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(6);
+    });
+});
+
+describe('Issue #317', () => {
+    it('should tests for default values, and focus on it', () => {
+        browser.url(testUrl);
+
+        expect(browser.getValue(selectors.issue317input)).toEqual('0.00');
+    });
+
+    it('should move the caret correctly when the value is zero', () => {
+        // Focus in the issue input
+        const input = $(selectors.issue317input);
+        input.click();
+
+        // Set the caret position to  // 0|.00
+        browser.keys(['Home', 'ArrowRight', 'ArrowLeft']);
+
+        // Try to enter a '0' that will be dropped
+        browser.keys('0');
+
+        // Check that the value did not change, and the the caret is correctly positionned
+        expect(browser.getValue(selectors.issue317input)).toEqual('0.00');
+        const inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_317');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(1);
+    });
+
+    it('should move the caret correctly when the value is zero', () => {
+        // Set the value to 2.342.423.423.423
+        browser.setValue(selectors.issue317input, 2342423423423);
+        browser.keys('.00'); // This is used to force autoNumeric to reformat the value, while adding the 'empty' decimal places
+
+        // Set the caret position to  // 0|.00
+        browser.keys(['End', 'ArrowLeft', 'ArrowLeft']);
+
+        // Try to enter a '9' that will be dropped
+        browser.keys('9');
+
+        // Check that the value did not change, and the the caret is correctly positionned
+        expect(browser.getValue(selectors.issue317input)).toEqual('2,342,423,423,423.00');
+        let inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_317');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(17);
+
+        // Enter a decimal character that will make the caret move into the decimal place part
+        // ...with the alternate decimal character
+        browser.keys(',');
+        expect(browser.getValue(selectors.issue317input)).toEqual('2,342,423,423,423.00');
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_317');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(18);
+
+        // ...with the period '.'
+        browser.keys('ArrowLeft');
+        browser.keys('.');
+        expect(browser.getValue(selectors.issue317input)).toEqual('2,342,423,423,423.00');
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_317');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(18);
+
+        // ...with the numpad dot
+        browser.keys('ArrowLeft');
+        browser.keys('Decimal');
+        expect(browser.getValue(selectors.issue317input)).toEqual('2,342,423,423,423.00');
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_317');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(18);
+    });
+});
+
+xdescribe('Issue #303', () => { //FIXME Finish this
+    it('should tests for default values', () => {
+        browser.url(testUrl);
+
+        expect(browser.getValue(selectors.issue303inputP)).toEqual('');
+        expect(browser.getValue(selectors.issue303inputS)).toEqual('');
+    });
+
+
+    it('should position the caret at the right position, depending on the currencySymbolPlacement', () => {
+        // Focus in the non-an input
+        const input = $(selectors.issue303inputNonAn);
+        input.click();
+
+        // Then 'tab' to the next one
+        browser.keys('Tab');
+        expect(browser.getValue(selectors.issue303inputP)).toEqual('$'); //FIXME This fails while it should not
+        let inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_303p');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(1);
+
+
+        // Then 'tab' to the next one
+        browser.keys('Tab');
+        expect(browser.getValue(selectors.issue303inputS)).toEqual('\u00a0€'); //FIXME This fails while it should not
+        inputCaretPosition = browser.execute(() => {
+            const input = document.querySelector('#issue_303p');
+            return input.selectionStart;
+        }).value;
+        expect(inputCaretPosition).toEqual(0);
+    });
+});

--- a/test/e2e/wdio.local.conf.js
+++ b/test/e2e/wdio.local.conf.js
@@ -1,0 +1,249 @@
+// eslint-disable-next-line
+/* global exports, require, browser */
+
+exports.config = {
+    // ==================
+    // Specify Test Files
+    // ==================
+    // Define which test specs should run. The pattern is relative to the directory
+    // from which `wdio` was called. Notice that, if you are calling `wdio` from an
+    // NPM script (see https://docs.npmjs.com/cli/run-script) then the current working
+    // directory is where your package.json resides, so `wdio` will be called from there.
+    specs: [
+        './test/e2e/specs/**/*.js',
+    ],
+
+    // Patterns to exclude.
+    exclude: [
+        // 'path/to/excluded/files'
+    ],
+
+    // ============
+    // Capabilities
+    // ============
+    // Define your capabilities here. WebdriverIO can run multiple capabilities at the same
+    // time. Depending on the number of capabilities, WebdriverIO launches several test
+    // sessions. Within your capabilities you can overwrite the spec and exclude options in
+    // order to group specific specs to a specific capability.
+
+    // First, you can define how many instances should be started at the same time. Let's
+    // say you have 3 different capabilities (Chrome, Firefox, and Safari) and you have
+    // set maxInstances to 1; wdio will spawn 3 processes. Therefore, if you have 10 spec
+    // files and you set maxInstances to 10, all spec files will get tested at the same time
+    // and 30 processes will get spawned. The property handles how many capabilities
+    // from the same test should run tests.
+    maxInstances: 10,
+
+    // If you have trouble getting all important capabilities together, check out the
+    // Sauce Labs platform configurator - a great tool to configure your capabilities:
+    // https://docs.saucelabs.com/reference/platforms-configurator
+    capabilities: [
+        {
+            // maxInstances can get overwritten per capability. So if you have an in-house Selenium
+            // grid with only 5 firefox instances available you can make sure that not more than
+            // 5 instances get started at a time.
+            maxInstances: 5,
+            browserName : 'firefox',
+        },
+        {
+            browserName : 'chrome',
+        },
+        /*{
+            browserName   : 'firefox', // developer version
+            firefox_binary: '/home/user/.local/share/umake/web/firefox-dev/firefox', // Path to the executable
+        },*/
+    ],
+
+
+    // ===================
+    // Test Configurations
+    // ===================
+    // Define all options that are relevant for the WebdriverIO instance here
+
+    // By default WebdriverIO commands are executed in a synchronous way using
+    // the wdio-sync package. If you still want to run your tests in an async way
+    // e.g. using promises you can set the sync option to false.
+    sync: true,
+
+    // Level of logging verbosity: silent | verbose | command | data | result | error
+    logLevel: 'silent',
+
+    // Enables colors for log output.
+    coloredLogs: true,
+
+    // If you only want to run your tests until a specific amount of tests have failed use
+    // bail (default is 0 - don't bail, run all tests).
+    bail: 0,
+
+    // Saves a screenshot to a given path if a command fails.
+    screenshotPath: './test/e2e/screenshots/',
+
+    // Set a base URL in order to shorten url command calls. If your url parameter starts
+    // with "/", then the base url gets prepended.
+    baseUrl: 'http://localhost',
+
+    // Default timeout for all waitFor* commands.
+    waitforTimeout: 10000,
+
+    // Default timeout in milliseconds for request
+    // if Selenium Grid doesn't send response
+    connectionRetryTimeout: 90000,
+
+    // Default request retries count
+    connectionRetryCount: 3,
+
+    // Initialize the browser instance with a WebdriverIO plugin. The object should have the
+    // plugin name as key and the desired plugin options as properties. Make sure you have
+    // the plugin installed before running any tests. The following plugins are currently
+    // available:
+    // WebdriverCSS: https://github.com/webdriverio/webdrivercss
+    // WebdriverRTC: https://github.com/webdriverio/webdriverrtc
+    // Browserevent: https://github.com/webdriverio/browserevent
+    // plugins: {
+    //     webdrivercss: {
+    //         screenshotRoot: 'my-shots',
+    //         failedComparisonsRoot: 'diffs',
+    //         misMatchTolerance: 0.05,
+    //         screenWidth: [320,480,640,1024]
+    //     },
+    //     webdriverrtc: {},
+    //     browserevent: {}
+    // },
+
+    // Test runner services
+    // Services take over a specific job you don't want to take care of. They enhance
+    // your test setup with almost no effort. Unlike plugins, they don't add new
+    // commands. Instead, they hook themselves up into the test process.
+    // services: [],
+
+    // This is used to launch the selenium server automatically when calling `yarn test:e2e`
+    services           : [
+        'selenium-standalone',
+    ],
+    seleniumLogs       : 'test/e2e/selenium.log',
+    //XXX Using the latest v3.0.1 make the tests crash under Firefox. This is tracked here : https://github.com/SeleniumHQ/selenium/issues/2285
+    seleniumInstallArgs: {
+        version: '2.53.1',
+    },
+    seleniumArgs       : {
+        version: '2.53.1',
+    },
+
+    // Framework you want to run your specs with.
+    // The following are supported: Mocha, Jasmine, and Cucumber
+    // see also: http://webdriver.io/guide/testrunner/frameworks.html
+    // Make sure you have the wdio adapter package for the specific framework installed
+    // before running any tests.
+    framework: 'jasmine',
+
+    // Test reporter for stdout.
+    // The only one supported by default is 'dot'
+    // see also: http://webdriver.io/guide/testrunner/reporters.html
+    reporters: [
+        'spec',
+        // 'dot', // Install `wdio-dot-reporter` to activate that reporter
+    ],
+
+    // Options to be passed to Jasmine.
+    jasmineNodeOpts: {
+        // Jasmine default timeout
+        defaultTimeoutInterval: 15000,
+
+        // The Jasmine framework allows interception of each assertion in order to log the state of the application
+        // or website depending on the result. For example, it is pretty handy to take a screenshot every time
+        // an assertion fails.
+        /*
+        expectationResultHandler: function(passed, assertion) {
+            // do something
+        },
+        */
+        // Make use of Jasmine-specific grep functionality
+        grep: null,
+        invertGrep: null,
+    },
+    
+    //
+    // =====
+    // Hooks
+    // =====
+    // WebdriverIO provides several hooks you can use to interfere with the test process in order to enhance
+    // it and to build services around it. You can either apply a single function or an array of
+    // methods to it. If one of them returns with a promise, WebdriverIO will wait until that promise got
+    // resolved to continue.
+
+    // Gets executed once before all workers get launched.
+    // onPrepare: function (config, capabilities) {
+    // },
+
+    // Gets executed just before initialising the webdriver session and test framework. It allows you
+    // to manipulate configurations depending on the capability or spec.
+    // beforeSession: function (config, capabilities, specs) {
+    // },
+
+    // Gets executed before test execution begins. At this point you can access all global
+    // variables, such as `browser`. It is the perfect place to define custom commands.
+    // before: function (capabilities, specs) {
+    // },
+    before() {
+        // This allows to run babel before running the tests
+        require('babel-register');
+    },
+
+    // Hook that gets executed before the suite starts
+    // beforeSuite: function (suite) {
+    // },
+
+    // Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
+    // beforeEach in Mocha)
+    // beforeHook: function () {
+    // },
+
+    // Add the 'getCaretPosition()' function to `browser`
+    /*
+    beforeHook() {
+        //TODO Find a way to access the DOM element (`this` here does not work)
+        browser.addCommand('getCaretPosition', function() {
+            return this.selectionStart;
+        });
+    },
+    */
+
+    // Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
+    // afterEach in Mocha)
+    // afterHook: function () {
+    // },
+
+    // Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+    // beforeTest: function (test) {
+    // },
+
+    // Runs before a WebdriverIO command gets executed.
+    // beforeCommand: function (commandName, args) {
+    // },
+
+    // Runs after a WebdriverIO command gets executed
+    // afterCommand: function (commandName, args, result, error) {
+    // },
+
+    // Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
+    // afterTest: function (test) {
+    // },
+
+    // Hook that gets executed after the suite has ended
+    // afterSuite: function (suite) {
+    // },
+
+    // Gets executed after all tests are done. You still have access to all global variables from
+    // the test.
+    // after: function (result, capabilities, specs) {
+    // },
+
+    // Gets executed right after terminating the webdriver session.
+    // afterSession: function (config, capabilities, specs) {
+    // },
+
+    // Gets executed after all workers got shut down and the process is about to exit. It is not
+    // possible to defer the end of the process using a promise.
+    // onComplete: function(exitCode) {
+    // }
+};

--- a/test/unit/autoNumeric.spec.js
+++ b/test/unit/autoNumeric.spec.js
@@ -1,5 +1,5 @@
 /**
- * Tests for autoNumeric.js
+ * Unit tests for autoNumeric.js
  * @author Alexandre Bonneau <alexandre.bonneau@linuxfr.eu>
  * @copyright © 2016 Alexandre Bonneau
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,6 +77,30 @@ aproba@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.0.4.tgz#2713680775e7614c8ba186c065d4e2e52d1072c0"
 
+archiver-utils@^1.0.0, archiver-utils@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/archiver-utils/-/archiver-utils-1.3.0.tgz#e50b4c09c70bf3d680e32ff1b7994e9f9d895174"
+  dependencies:
+    glob "^7.0.0"
+    graceful-fs "^4.1.0"
+    lazystream "^1.0.0"
+    lodash "^4.8.0"
+    normalize-path "^2.0.0"
+    readable-stream "^2.0.0"
+
+archiver@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/archiver/-/archiver-1.0.0.tgz#de1d61082e947755b599bb3bc27130a4c859fc83"
+  dependencies:
+    archiver-utils "^1.0.0"
+    async "^1.5.0"
+    buffer-crc32 "^0.2.1"
+    glob "^7.0.0"
+    lodash "^4.8.0"
+    readable-stream "^2.0.0"
+    tar-stream "^1.5.0"
+    zip-stream "^1.0.0"
+
 are-we-there-yet@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz#80e470e95a084794fe1899262c5667c6e88de1b3"
@@ -152,13 +176,23 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
-async@1.x, async@^1.3.0, async@^1.4.0:
+async@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.2.1.tgz#a4816a17cd5ff516dfa2c7698a453369b9790de0"
+
+async@1.x, async@^1.3.0, async@^1.4.0, async@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
 async@^0.9.0, async@~0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
+
+async@^2.0.1:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.1.4.tgz#2d2160c7788032e4dd6cbe2502f1f9a2c8f6cde4"
+  dependencies:
+    lodash "^4.14.0"
 
 async@~0.2.6:
   version "0.2.10"
@@ -167,6 +201,10 @@ async@~0.2.6:
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+
+atob@~1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -184,7 +222,39 @@ babel-code-frame@^6.16.0, babel-code-frame@^6.20.0:
     esutils "^2.0.2"
     js-tokens "^2.0.0"
 
-babel-core@6.x.x, babel-core@^6.18.0, babel-core@latest:
+babel-code-frame@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
+  dependencies:
+    chalk "^1.1.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+babel-core@6.x.x, babel-core@^6.22.0:
+  version "6.22.1"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.22.1.tgz#9c5fd658ba1772d28d721f6d25d968fc7ae21648"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-generator "^6.22.0"
+    babel-helpers "^6.22.0"
+    babel-messages "^6.22.0"
+    babel-register "^6.22.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.22.0"
+    babel-traverse "^6.22.1"
+    babel-types "^6.22.0"
+    babylon "^6.11.0"
+    convert-source-map "^1.1.0"
+    debug "^2.1.1"
+    json5 "^0.5.0"
+    lodash "^4.2.0"
+    minimatch "^3.0.2"
+    path-is-absolute "^1.0.0"
+    private "^0.1.6"
+    slash "^1.0.0"
+    source-map "^0.5.0"
+
+babel-core@latest:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.21.0.tgz#75525480c21c803f826ef3867d22c19f080a3724"
   dependencies:
@@ -225,6 +295,18 @@ babel-generator@^6.21.0:
     babel-messages "^6.8.0"
     babel-runtime "^6.20.0"
     babel-types "^6.21.0"
+    detect-indent "^4.0.0"
+    jsesc "^1.3.0"
+    lodash "^4.2.0"
+    source-map "^0.5.0"
+
+babel-generator@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.22.0.tgz#d642bf4961911a8adc7c692b0c9297f325cda805"
+  dependencies:
+    babel-messages "^6.22.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.22.0"
     detect-indent "^4.0.0"
     jsesc "^1.3.0"
     lodash "^4.2.0"
@@ -331,6 +413,13 @@ babel-helpers@^6.16.0:
     babel-runtime "^6.0.0"
     babel-template "^6.16.0"
 
+babel-helpers@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-helpers/-/babel-helpers-6.22.0.tgz#d275f55f2252b8101bff07bc0c556deda657392c"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-template "^6.22.0"
+
 babel-istanbul-loader@latest:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/babel-istanbul-loader/-/babel-istanbul-loader-0.1.0.tgz#3c45b0e66de03ceb6b48e82eac25fc06f39500ad"
@@ -391,6 +480,12 @@ babel-loader@6.2.x, babel-loader@latest:
     loader-utils "^0.2.11"
     mkdirp "^0.5.1"
     object-assign "^4.0.1"
+
+babel-messages@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.22.0.tgz#36066a214f1217e4ed4164867669ecb39e3ea575"
+  dependencies:
+    babel-runtime "^6.22.0"
 
 babel-messages@^6.8.0:
   version "6.8.0"
@@ -668,26 +763,49 @@ babel-preset-latest@latest:
     babel-preset-es2016 "^6.16.0"
     babel-preset-es2017 "^6.16.0"
 
-babel-register@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.18.0.tgz#892e2e03865078dd90ad2c715111ec4449b32a68"
+babel-register@^6.18.0, babel-register@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.22.0.tgz#a61dd83975f9ca4a9e7d6eff3059494cd5ea4c63"
   dependencies:
-    babel-core "^6.18.0"
-    babel-runtime "^6.11.6"
+    babel-core "^6.22.0"
+    babel-runtime "^6.22.0"
     core-js "^2.4.0"
     home-or-tmp "^2.0.0"
     lodash "^4.2.0"
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.20.0, babel-runtime@^6.9.0:
+babel-runtime@^5.8.25:
+  version "5.8.38"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-5.8.38.tgz#1c0b02eb63312f5f087ff20450827b425c9d4c19"
+  dependencies:
+    core-js "^1.0.0"
+
+babel-runtime@^6.0.0, babel-runtime@^6.20.0, babel-runtime@^6.9.2:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.20.0.tgz#87300bdcf4cd770f09bf0048c64204e17806d16f"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.16.0, babel-template@^6.8.0:
+babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.9.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.22.0.tgz#1cf8b4ac67c77a4ddb0db2ae1f74de52ac4ca611"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
+babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.22.0, babel-template@^6.8.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.22.0.tgz#403d110905a4626b317a2a1fcb8f3b73204b2edb"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.22.0"
+    babel-types "^6.22.0"
+    babylon "^6.11.0"
+    lodash "^4.2.0"
+
+babel-template@^6.16.0:
   version "6.16.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.16.0.tgz#e149dd1a9f03a35f817ddbc4d0481988e7ebc8ca"
   dependencies:
@@ -697,7 +815,7 @@ babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.16.0, babel-te
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.15.0, babel-traverse@^6.16.0, babel-traverse@^6.18.0, babel-traverse@^6.20.0, babel-traverse@^6.21.0:
+babel-traverse@^6.15.0, babel-traverse@^6.16.0, babel-traverse@^6.21.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.21.0.tgz#69c6365804f1a4f69eb1213f85b00a818b8c21ad"
   dependencies:
@@ -711,7 +829,21 @@ babel-traverse@^6.15.0, babel-traverse@^6.16.0, babel-traverse@^6.18.0, babel-tr
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.15.0, babel-types@^6.16.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.20.0, babel-types@^6.21.0, babel-types@^6.8.0, babel-types@^6.9.0:
+babel-traverse@^6.18.0, babel-traverse@^6.20.0, babel-traverse@^6.22.0, babel-traverse@^6.22.1:
+  version "6.22.1"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.22.1.tgz#3b95cd6b7427d6f1f757704908f2fc9748a5f59f"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-messages "^6.22.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.22.0"
+    babylon "^6.15.0"
+    debug "^2.2.0"
+    globals "^9.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+babel-types@^6.15.0, babel-types@^6.16.0, babel-types@^6.21.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.21.0.tgz#314b92168891ef6d3806b7f7a917fdf87c11a4b2"
   dependencies:
@@ -720,7 +852,16 @@ babel-types@^6.15.0, babel-types@^6.16.0, babel-types@^6.18.0, babel-types@^6.19
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.11.0, babylon@^6.13.0:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.20.0, babel-types@^6.22.0, babel-types@^6.8.0, babel-types@^6.9.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.22.0.tgz#2a447e8d0ea25d2512409e4175479fd78cc8b1db"
+  dependencies:
+    babel-runtime "^6.22.0"
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^1.0.1"
+
+babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0:
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
 
@@ -764,7 +905,7 @@ binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
 
-bl@~1.1.2:
+bl@^1.0.0, bl@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-1.1.2.tgz#fdca871a99713aa00d19e3bbba41c44787a65398"
   dependencies:
@@ -781,8 +922,8 @@ block-stream@*:
     inherits "~2.0.0"
 
 bluebird@^3.3.0:
-  version "3.4.7"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
+  version "3.4.6"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.6.tgz#01da8d821d87813d158967e743d5fe6c62cf8c0f"
 
 body-parser@^1.12.4:
   version "1.15.2"
@@ -837,6 +978,10 @@ browserify-zlib@^0.1.4:
   resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.1.4.tgz#bb35f8a519f600e0fa6b8485241c979d0141fb2d"
   dependencies:
     pako "~0.2.0"
+
+buffer-crc32@^0.2.1, buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
 
 buffer-shims@^1.0.0:
   version "1.0.0"
@@ -977,6 +1122,10 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.6.0.tgz#9df7e52fb2a0cb0fb89058ee80c3104225f37e1d"
+
 commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
@@ -1003,6 +1152,15 @@ component-inherit@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
 
+compress-commons@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/compress-commons/-/compress-commons-1.1.0.tgz#9f4460bb1288564c7473916e0298aa3c320dcadb"
+  dependencies:
+    buffer-crc32 "^0.2.1"
+    crc32-stream "^1.0.0"
+    normalize-path "^2.0.0"
+    readable-stream "^2.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1015,7 +1173,7 @@ concat-stream@1.5.0:
     readable-stream "~2.0.0"
     typedarray "~0.0.5"
 
-concat-stream@^1.4.6:
+concat-stream@^1.4.6, concat-stream@^1.4.7:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -1058,6 +1216,10 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+
 core-js@^2.2.0, core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
@@ -1076,6 +1238,17 @@ coveralls@^2.11.15:
     minimist "1.2.0"
     request "2.75.0"
 
+crc32-stream@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/crc32-stream/-/crc32-stream-1.0.1.tgz#ce2c5dc3bd8ffb3830f9cb47f540222c63c90fab"
+  dependencies:
+    crc "^3.4.4"
+    readable-stream "^2.0.0"
+
+crc@^3.4.4:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/crc/-/crc-3.4.4.tgz#9da1e980e3bd44fc5c93bf5ab3da3378d85e466b"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -1090,6 +1263,25 @@ crypto-browserify@3.3.0:
     pbkdf2-compat "2.0.1"
     ripemd160 "0.2.0"
     sha.js "2.2.6"
+
+css-parse@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/css-parse/-/css-parse-2.0.0.tgz#a468ee667c16d81ccf05c58c38d2a97c780dbfd4"
+  dependencies:
+    css "^2.0.0"
+
+css-value@~0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/css-value/-/css-value-0.0.1.tgz#5efd6c2eea5ea1fd6b6ac57ec0427b18452424ea"
+
+css@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.1.tgz#73a4c81de85db664d4ee674f7d47085e3b2d55dc"
+  dependencies:
+    inherits "^2.0.1"
+    source-map "^0.1.38"
+    source-map-resolve "^0.3.0"
+    urix "^0.1.0"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -1158,6 +1350,17 @@ deep-is@~0.1.2, deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+deepmerge@^0.2.10:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-0.2.10.tgz#8906bf9e525a4fbf1b203b2afcb4640249821219"
+
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
+
 del@^2.0.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
@@ -1222,9 +1425,19 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
+ejs@^2.3.1:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.5.tgz#6ef4e954ea7dcf54f66aad2fe7aa421932d9ed77"
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
+
+end-of-stream@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.1.0.tgz#e9353258baa9108965efc41cb0ef8ade2f3cfb07"
+  dependencies:
+    once "~1.3.0"
 
 engine.io-client@1.8.2:
   version "1.8.2"
@@ -1484,6 +1697,10 @@ exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
+exit@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+
 expand-braces@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/expand-braces/-/expand-braces-0.1.2.tgz#488b1d1d2451cb3d3a6b192cfc030f44c5855fea"
@@ -1514,6 +1731,14 @@ expand-range@^1.8.1:
 extend@^3.0.0, extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
+
+external-editor@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-1.1.1.tgz#12d7b0db850f7ff7e7081baf4005700060c4600b"
+  dependencies:
+    extend "^3.0.0"
+    spawn-sync "^1.0.15"
+    tmp "^0.0.29"
 
 extglob@^0.3.1:
   version "0.3.2"
@@ -1547,6 +1772,10 @@ fd-slicer@~1.0.1:
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
   dependencies:
     pend "~1.2.0"
+
+fibers@^1.0.9:
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/fibers/-/fibers-1.0.15.tgz#22f039c8f18b856190fbbe4decf056154c1eae9c"
 
 figures@^1.3.5:
   version "1.7.0"
@@ -1627,9 +1856,21 @@ for-own@^0.1.4:
   dependencies:
     for-in "^0.1.5"
 
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+
+form-data@~1.0.0-rc4:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-1.0.1.tgz#ae315db9a4907fa065502304a66d7733475ee37c"
+  dependencies:
+    async "^2.0.1"
+    combined-stream "^1.0.5"
+    mime-types "^2.1.11"
 
 form-data@~2.0.0:
   version "2.0.0"
@@ -1652,6 +1893,16 @@ fs-access@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-access/-/fs-access-1.0.1.tgz#d6a87f262271cefebec30c553407fb995da8777a"
   dependencies:
     null-check "^1.0.0"
+
+fs-extra@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+    klaw "^1.0.0"
+    path-is-absolute "^1.0.0"
+    rimraf "^2.2.8"
 
 fs-extra@~1.0.0:
   version "1.0.0"
@@ -1689,6 +1940,10 @@ fstream@^1.0.0, fstream@^1.0.2, fstream@~1.0.10:
     mkdirp ">=0.5 0"
     rimraf "2"
 
+function-bind@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
+
 gauge@~2.7.1:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.2.tgz#15cecc31b02d05345a5d6b0e171cdb3ad2307774"
@@ -1702,6 +1957,12 @@ gauge@~2.7.1:
     strip-ansi "^3.0.1"
     supports-color "^0.2.0"
     wide-align "^1.1.0"
+
+gaze@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/gaze/-/gaze-1.1.2.tgz#847224677adb8870d679257ed3388fdb61e40105"
+  dependencies:
+    globule "^1.0.0"
 
 generate-function@^2.0.0:
   version "2.0.0"
@@ -1746,7 +2007,7 @@ glob@5.x, glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@~7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -1772,7 +2033,15 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+globule@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/globule/-/globule-1.1.0.tgz#c49352e4dc183d85893ee825385eb994bb6df45f"
+  dependencies:
+    glob "~7.1.1"
+    lodash "~4.16.4"
+    minimatch "~3.0.2"
+
+graceful-fs@^4.1.0, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -1881,6 +2150,10 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
+humanize-duration@^3.9.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/humanize-duration/-/humanize-duration-3.10.0.tgz#4d15bccaefcb12401b4d80475cf6c49a039e3959"
+
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
@@ -1951,6 +2224,25 @@ inquirer@^0.12.0:
     strip-ansi "^3.0.0"
     through "^2.3.6"
 
+inquirer@^1.1.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-1.2.3.tgz#4dec6f32f37ef7bb0b2ed3f1d1a5c3f545074918"
+  dependencies:
+    ansi-escapes "^1.1.0"
+    chalk "^1.0.0"
+    cli-cursor "^1.0.1"
+    cli-width "^2.0.0"
+    external-editor "^1.1.0"
+    figures "^1.3.5"
+    lodash "^4.3.0"
+    mute-stream "0.0.6"
+    pinkie-promise "^2.0.0"
+    run-async "^2.2.0"
+    rx "^4.1.0"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.0"
+    through "^2.3.6"
+
 interpret@^0.6.4:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-0.6.6.tgz#fecd7a18e7ce5ca6abfb953e1f86213a49f1625b"
@@ -1964,6 +2256,12 @@ invariant@^2.2.0:
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
     loose-envify "^1.0.0"
+
+is-absolute@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/is-absolute/-/is-absolute-0.1.7.tgz#847491119fccb5fb436217cc737f7faad50f603f"
+  dependencies:
+    is-relative "^0.1.0"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -2068,9 +2366,17 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+
+is-relative@^0.1.0:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/is-relative/-/is-relative-0.1.3.tgz#905fee8ae86f45b3ec614bc3c15c869df0876e82"
 
 is-resolvable@^1.0.0:
   version "1.0.0"
@@ -2135,9 +2441,17 @@ istanbul@^0.4.0:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
-jasmine-core@latest:
+jasmine-core@latest, jasmine-core@~2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-2.5.2.tgz#6f61bd79061e27f43e6f9355e44b3c6cab6ff297"
+
+jasmine@^2.5.2:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-2.5.3.tgz#5441f254e1fc2269deb1dfd93e0e57d565ff4d22"
+  dependencies:
+    exit "^0.1.2"
+    glob "^7.0.6"
+    jasmine-core "~2.5.2"
 
 jodid25519@^1.0.0:
   version "1.0.2"
@@ -2152,6 +2466,10 @@ jquery@>=1.7:
 js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
+
+js-tokens@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.0.tgz#a2f2a969caae142fb3cd56228358c89366957bd1"
 
 js-yaml@3.6.1:
   version "3.6.1"
@@ -2189,7 +2507,7 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -2323,6 +2641,12 @@ lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
 
+lazystream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4"
+  dependencies:
+    readable-stream "^2.0.5"
+
 lcov-parse@0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
@@ -2364,13 +2688,21 @@ lodash.pickby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
 
+lodash@3.9.3:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.9.3.tgz#0159e86832feffc6d61d852b12a953b99496bd32"
+
 lodash@3.x, lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.0.1, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0:
+lodash@^4.0.0, lodash@^4.0.1, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0, lodash@^4.8.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@~4.16.4:
+  version "4.16.6"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.6.tgz#d22c9ac660288f3843e16ba7d2b5d06cca27d777"
 
 log-driver@1.2.5:
   version "1.2.5"
@@ -2477,7 +2809,7 @@ mime@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2:
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
@@ -2492,6 +2824,10 @@ minimatch@2.x:
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+
+minimist@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.0.tgz#cdf225e8898f840a258ded44fc91776770afdc93"
 
 minimist@1.2.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
@@ -2528,6 +2864,10 @@ multi-glob@^1.0.1:
 mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+
+mute-stream@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.6.tgz#48962b19e169fd1dfc240b3f1e7317627bbc47db"
 
 nan@^2.3.0:
   version "2.5.0"
@@ -2587,6 +2927,10 @@ node-uuid@~1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.7.tgz#6da5a17668c4b3dd59623bda11cf7fa4c1f60a6f"
 
+noop2@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/noop2/-/noop2-2.0.0.tgz#4b636015e9882b54783c02b412f699d8c5cd0a5b"
+
 nopt@3.x, nopt@~3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
@@ -2602,9 +2946,15 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^2.0.1:
+normalize-path@^2.0.0, normalize-path@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.0.1.tgz#47886ac1662760d4261b7d979d241709d3ce3f7a"
+
+npm-install-package@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/npm-install-package/-/npm-install-package-1.1.0.tgz#f9fc1f84c2d31f6105631e0b5f5f280d1151d97e"
+  dependencies:
+    noop2 "^2.0.0"
 
 npmlog@^4.0.1:
   version "4.0.2"
@@ -2639,6 +2989,18 @@ object-component@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
 
+object-keys@^1.0.10, object-keys@^1.0.8:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object.assign@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.0.4.tgz#b1c9cc044ef1b9fe63606fc141abbb32e14730cc"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.0"
+    object-keys "^1.0.10"
+
 object.omit@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
@@ -2658,7 +3020,7 @@ once@1.x, once@^1.3.0:
   dependencies:
     wrappy "1"
 
-once@~1.3.3:
+once@~1.3.0, once@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/once/-/once-1.3.3.tgz#b2e261557ce4c314ec8304f3fa82663e4297ca20"
   dependencies:
@@ -2708,6 +3070,10 @@ os-browserify@^0.2.0:
 os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+
+os-shim@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
 
 os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
   version "1.0.2"
@@ -2846,7 +3212,7 @@ process@^0.11.0:
   version "0.11.9"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.9.tgz#7bd5ad21aa6253e7da8682264f1e11d11c0318c1"
 
-progress@^1.1.8, progress@~1.1.8:
+progress@1.1.8, progress@^1.1.8, progress@~1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
@@ -2854,13 +3220,17 @@ prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
 
-punycode@1.3.2:
+punycode@1.3.2, punycode@^1.2.4:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
 
-punycode@^1.2.4, punycode@^1.4.1:
+punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+q@~1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/q/-/q-1.4.1.tgz#55705bcd93c5f3673530c2c2cbc0c2b3addc286e"
 
 qjobs@^1.1.4:
   version "1.1.5"
@@ -2925,7 +3295,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.0, readable-stream@^2.2.2:
+readable-stream@^2.0.0, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.0, readable-stream@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
   dependencies:
@@ -3064,6 +3434,32 @@ request-progress@~2.0.1:
   dependencies:
     throttleit "^1.0.0"
 
+request@2.74.0:
+  version "2.74.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.74.0.tgz#7693ca768bbb0ea5c8ce08c084a45efa05b892ab"
+  dependencies:
+    aws-sign2 "~0.6.0"
+    aws4 "^1.2.1"
+    bl "~1.1.2"
+    caseless "~0.11.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~1.0.0-rc4"
+    har-validator "~2.0.6"
+    hawk "~3.1.3"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    node-uuid "~1.4.7"
+    oauth-sign "~0.8.1"
+    qs "~6.2.0"
+    stringstream "~0.0.4"
+    tough-cookie "~2.3.0"
+    tunnel-agent "~0.4.1"
+
 request@2.75.0:
   version "2.75.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.75.0.tgz#d2b8268a286da13eaa5d01adf5d18cc90f657d93"
@@ -3090,7 +3486,7 @@ request@2.75.0:
     tough-cookie "~2.3.0"
     tunnel-agent "~0.4.1"
 
-request@^2.79.0, request@~2.79.0:
+request@2.79.0, request@^2.79.0, request@~2.79.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -3130,6 +3526,10 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
+resolve-url@~0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+
 resolve@1.1.x, resolve@^1.1.6:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
@@ -3140,6 +3540,10 @@ restore-cursor@^1.0.1:
   dependencies:
     exit-hook "^1.0.0"
     onetime "^1.0.0"
+
+rgb2hex@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/rgb2hex/-/rgb2hex-0.1.0.tgz#ccd55f860ae0c5c4ea37504b958e442d8d12325b"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -3163,13 +3567,39 @@ run-async@^0.1.0:
   dependencies:
     once "^1.3.0"
 
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+  dependencies:
+    is-promise "^2.1.0"
+
 rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+rx@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
+
 safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+
+selenium-standalone@^5.6.0:
+  version "5.11.1"
+  resolved "https://registry.yarnpkg.com/selenium-standalone/-/selenium-standalone-5.11.1.tgz#aaa323e5c74c82e9d4293ae367c70c2bfa89aa01"
+  dependencies:
+    async "1.2.1"
+    commander "2.6.0"
+    lodash "3.9.3"
+    minimist "1.1.0"
+    mkdirp "0.5.0"
+    progress "1.1.8"
+    request "2.79.0"
+    tar-stream "1.5.2"
+    urijs "1.16.1"
+    which "1.1.1"
+    yauzl "^2.5.0"
 
 "semver@2 || 3 || 4 || 5", semver@~5.3.0:
   version "5.3.0"
@@ -3273,11 +3703,24 @@ source-list-map@~0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
 
+source-map-resolve@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.3.1.tgz#610f6122a445b8dd51535a2a71b783dfc1248761"
+  dependencies:
+    atob "~1.1.0"
+    resolve-url "~0.2.1"
+    source-map-url "~0.3.0"
+    urix "~0.1.0"
+
 source-map-support@^0.4.2:
   version "0.4.8"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.8.tgz#4871918d8a3af07289182e974e32844327b2e98b"
   dependencies:
     source-map "^0.5.3"
+
+source-map-url@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.3.0.tgz#7ecaf13b57bcd09da8a40c5d269db33799d4aaf9"
 
 source-map@0.4.x, source-map@^0.4.4, source-map@~0.4.1:
   version "0.4.4"
@@ -3285,7 +3728,7 @@ source-map@0.4.x, source-map@^0.4.4, source-map@~0.4.1:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.1.41:
+source-map@^0.1.38, source-map@^0.1.41:
   version "0.1.43"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
   dependencies:
@@ -3300,6 +3743,13 @@ source-map@~0.2.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
   dependencies:
     amdefine ">=0.0.4"
+
+spawn-sync@^1.0.15:
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
+  dependencies:
+    concat-stream "^1.4.7"
+    os-shim "^0.1.2"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -3408,7 +3858,7 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-supports-color@3.1.x, supports-color@^3.1.0:
+supports-color@3.1.x, supports-color@^3.1.0, supports-color@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -3450,6 +3900,15 @@ tar-pack@~3.3.0:
     tar "~2.2.1"
     uid-number "~0.0.6"
 
+tar-stream@1.5.2, tar-stream@^1.5.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.5.2.tgz#fbc6c6e83c1a19d4cb48c7d96171fc248effc7bf"
+  dependencies:
+    bl "^1.0.0"
+    end-of-stream "^1.0.0"
+    readable-stream "^2.0.0"
+    xtend "^4.0.0"
+
 tar@~2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
@@ -3479,6 +3938,12 @@ timers-browserify@^2.0.2:
 tmp@0.0.28:
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.28.tgz#172735b7f614ea7af39664fa84cf0de4e515d120"
+  dependencies:
+    os-tmpdir "~1.0.1"
+
+tmp@^0.0.29:
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.29.tgz#f25125ff0dd9da3ccb0c2dd371ee1288bb9128c0"
   dependencies:
     os-tmpdir "~1.0.1"
 
@@ -3562,6 +4027,14 @@ unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 
+urijs@1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.16.1.tgz#859ad31890f5f9528727be89f1932c94fb4731e2"
+
+urix@^0.1.0, urix@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -3606,6 +4079,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
+validator@^5.4.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-5.7.0.tgz#7a87a58146b695ac486071141c0c49d67da05e5c"
+
 verror@1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
@@ -3629,6 +4106,67 @@ watchpack@^0.2.1:
     async "^0.9.0"
     chokidar "^1.0.0"
     graceful-fs "^4.1.2"
+
+wdio-dot-reporter@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/wdio-dot-reporter/-/wdio-dot-reporter-0.0.6.tgz#153b3e1c5d76777190d893480ffa6f37833740f1"
+  dependencies:
+    babel-runtime "^5.8.25"
+
+wdio-jasmine-framework@^0.2.19:
+  version "0.2.19"
+  resolved "https://registry.yarnpkg.com/wdio-jasmine-framework/-/wdio-jasmine-framework-0.2.19.tgz#2a17de88541bfc58fe6af80fb2c39e4c3e4784ba"
+  dependencies:
+    babel-runtime "^5.8.25"
+    jasmine "^2.5.2"
+    wdio-sync "0.6.10"
+
+wdio-selenium-standalone-service@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/wdio-selenium-standalone-service/-/wdio-selenium-standalone-service-0.0.7.tgz#78c00e996d1242285b62aa6abbd5c3544b1eb3e1"
+  dependencies:
+    fs-extra "^0.30.0"
+    selenium-standalone "^5.6.0"
+
+wdio-spec-reporter@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/wdio-spec-reporter/-/wdio-spec-reporter-0.0.5.tgz#d0fb8fd14af153fe010051bb740aa30ab31063f5"
+  dependencies:
+    babel-runtime "^5.8.25"
+    humanize-duration "^3.9.0"
+
+wdio-sync@0.6.10:
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/wdio-sync/-/wdio-sync-0.6.10.tgz#e67ec663b0dca733bf2b676c7561f23876378387"
+  dependencies:
+    fibers "^1.0.9"
+    object.assign "^4.0.3"
+
+webdriverio@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/webdriverio/-/webdriverio-4.6.1.tgz#a5c53a7e62ad38e8e0ad08bdc305b02b0f9e4795"
+  dependencies:
+    archiver "1.0.0"
+    babel-runtime "^6.9.2"
+    css-parse "~2.0.0"
+    css-value "~0.0.1"
+    deepmerge "^0.2.10"
+    ejs "^2.3.1"
+    gaze "^1.1.2"
+    glob "^7.0.5"
+    inquirer "^1.1.2"
+    json-stringify-safe "^5.0.1"
+    mkdirp "^0.5.1"
+    npm-install-package "^1.0.2"
+    optimist "^0.6.1"
+    q "~1.4.1"
+    request "2.74.0"
+    rgb2hex "~0.1.0"
+    supports-color "^3.1.2"
+    url "^0.11.0"
+    validator "^5.4.0"
+    wdio-dot-reporter "^0.0.6"
+    wgxpath "~1.0.0"
 
 webpack-core@~0.6.9:
   version "0.6.9"
@@ -3665,6 +4203,16 @@ webpack@latest:
     uglify-js "~2.7.3"
     watchpack "^0.2.1"
     webpack-core "~0.6.9"
+
+wgxpath@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wgxpath/-/wgxpath-1.0.0.tgz#eef8a4b9d558cc495ad3a9a2b751597ecd9af690"
+
+which@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.1.1.tgz#9ce512459946166e12c083f08ec073380fc8cbbb"
+  dependencies:
+    is-absolute "^0.1.7"
 
 which@1.2.x, which@^1.1.1, which@^1.2.1, which@~1.2.10:
   version "1.2.12"
@@ -3738,6 +4286,22 @@ yauzl@2.4.1:
   dependencies:
     fd-slicer "~1.0.1"
 
+yauzl@^2.5.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.7.0.tgz#e21d847868b496fc29eaec23ee87fdd33e9b2bce"
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.0.1"
+
 yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
+
+zip-stream@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/zip-stream/-/zip-stream-1.1.1.tgz#5216b48bbb4d2651f64d5c6e6f09eb4a7399d557"
+  dependencies:
+    archiver-utils "^1.3.0"
+    compress-commons "^1.1.0"
+    lodash "^4.8.0"
+    readable-stream "^2.0.0"


### PR DESCRIPTION
Fix the test for a negative sign in `_getUnformattedLeftAndRightPartAroundTheSelection()` and `_normalizeParts()`.
Create a `character()` function that returns the real character being typed in events.
This `character()` function solves the potential compatibility problem with old browsers that do not correctly implement the `event.key` attribute.
Replace all calls to `event.key` with a call to the new `character()` function.
This changes allow autoNumeric to work with the Selenium server (which does not set correctly the `e.key` attribute, cf. related issue https://github.com/webdriverio/webdriverio/issues/1829).
Add the `test/e2e/index.html` file that store all the form inputs and autoNumeric configurations for the end-to-end tests.