### PR TITLE
Fix Travis tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "webpack": "latest"
   },
   "scripts": {
+    "postinstall": "node node_modules/phantomjs-prebuilt/install.js",
     "build:dev": "webpack src/autoNumeric.js dist/autoNumeric.js --config config/webpack.config.dev.js",
     "build:prd": "webpack src/autoNumeric.js dist/autoNumeric.min.js --config config/webpack.config.prd.js",
     "build": "yarn run clean:build && yarn run build:dev && yarn run build:prd",


### PR DESCRIPTION
Using `yarn` does not execute `install.js` in the `phantomjs-prebuilt` package.
Workaround mentionned here : https://github.com/karma-runner/karma-phantomjs-launcher/issues/120