### PR TITLE
Fix issue #387 Add a 'cancellable' feature & Fix issue #391

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### Change log for autoNumeric:
 
+### "3.0.0-beta.1"
++ Fix issue #387 Add a 'cancellable' feature
++ Fix issue #391 The currency symbol is selected when focusing on an input via the `Tab` key, when `selectNumberOnly` is set to `true`
++ Refactor the code to create a `_selectOnlyNumbers()` function that extract that behavior for re-use.
++ Create a `_select()` function that select the whole element content, while respecting the `selectNumberOnly` option.
++ Create a `_defaultSelectAll()` function that select the whole element content, including all characters.
++ Modify the `setElementSelection()` calls to simplify them with the ability to use one argument instead of two when the `start` and `end` position are the same.
++ Add a feature where when the user hit 'Escape', the element content is selected (cf. issue #387).
+
 ### "2.0.8"
 + Fix issue #389 autoNumeric 2.0.7 npm packages causes build error with typescriptify + browserify
 
@@ -50,9 +59,9 @@
 + Fix issue #339 `get` returns `'0'` when the input is empty even if `emptyInputBehavior` is not equal to `'zero'`
 
 ### "2.0.0-beta.17"
-+ Fix issue #317 allow jumping over the decimal character when the caret is just left of the decimal character and the user enters the decimal character
-+ Fix issue #319 so the 'get' method returns a negative value when there is a trailing negative sign.
-+ Fix issue #327 so the entire content is selected when tabbing in. 
++ Fix issue #317 Jump over the decimal character when trying to enter a number and the integer part limit has already been attained
++ Fix issue #319 'get' returns wrong value when the value has a trailing negative sign
++ Fix issue #327 When focusing on an input via the `Tab` key, the value is not always selected 
 
 ### "2.0.0-beta.16"
 + Fix issue #321 Allows more international decimal characters and grouping separators :

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autonumeric",
-  "version": "2.0.8",
+  "version": "3.0.0-beta.1",
   "description": "autoNumeric is a library that provides live *as-you-type* formatting for international numbers and currencies. It supports most International numeric formats and currencies including those used in Europe, Asia, and North and South America.",
   "main": "src/autoNumeric.js",
   "readmeFilename": "README.MD",

--- a/test/e2e/index.html
+++ b/test/e2e/index.html
@@ -47,6 +47,10 @@
 			transition : border 0.3s ease;
 		}
 
+		.testSuite:last-child {
+			margin-bottom: 4rem;
+		}
+
 		.testSuite:hover {
 			border : 1px solid lime;
 		}
@@ -111,8 +115,12 @@
 			text-decoration : underline;
 		}
 	</style>
+	<!-- Used by the end-to-end server spin up for the tests : -->
 	<script src="/jquery"></script>
 	<script src="/autonumeric"></script>
+	<!--<script src="../../node_modules/jquery/dist/jquery.min.js"></script>-->
+	<!--<script src="../../dist/autoNumeric.min.js"></script>-->
+	<!-- ^ Used by the page when calling it manually directly in the browser -->
 </head>
 <body>
 <div class="container">
@@ -324,6 +332,22 @@
 				<input id="issue_303non_an" type="text" placeholder="#303">
 				<input id="issue_303p" type="text" placeholder="#303" value="">
 				<input id="issue_303s" type="text" placeholder="#303" value="">
+			</div>
+		</div>
+	</div>
+
+	<div class="testSuite">
+		<div class="test">
+			<p class="description">Issue #387</p>
+			<div>
+				<div>
+					<input id="issue_387_cancellable" type="text" placeholder="#387" value="220242.76">
+					<input id="issue_387_cancellable_numOnly" type="text" placeholder="#387" value="220242.76">
+				</div>
+				<div>
+					<input id="issue_387_not_cancellable" type="text" placeholder="#387" value="220242.76">
+					<input id="issue_387_not_cancellable_numOnly" type="text" placeholder="#387" value="220242.76">
+				</div>
 			</div>
 		</div>
 	</div>
@@ -705,6 +729,17 @@
     issue303AInput.autoNumeric('init', { currencySymbolPlacement: 'p', currencySymbol: '$'      , /*emptyInputBehavior: 'always'*/ });
     const issue303BInput = $(document.querySelector('#issue_303s'));
     issue303BInput.autoNumeric('init', { currencySymbolPlacement: 's', currencySymbol: '\u00a0€', /*emptyInputBehavior: 'always'*/ });
+
+    //-------------- Issue #387
+    const issue387InputCancellable = $(document.querySelector('#issue_387_cancellable'));
+    issue387InputCancellable.autoNumeric('init', { isCancellable: true, currencySymbol: '$' });
+    const issue387InputCancellableNumOnly = $(document.querySelector('#issue_387_cancellable_numOnly'));
+    issue387InputCancellableNumOnly.autoNumeric('init', { isCancellable: true, selectNumberOnly: true, currencySymbol: '$' });
+
+    const issue387InputNotCancellable = $(document.querySelector('#issue_387_not_cancellable'));
+    issue387InputNotCancellable.autoNumeric('init', { isCancellable: false, currencySymbol: '$' });
+    const issue387InputNotCancellableNumOnly = $(document.querySelector('#issue_387_not_cancellable_numOnly'));
+    issue387InputNotCancellableNumOnly.autoNumeric('init', { isCancellable: false, selectNumberOnly: true, currencySymbol: '$' });
 </script>
 </body>
 </html>

--- a/test/unit/autoNumeric.spec.js
+++ b/test/unit/autoNumeric.spec.js
@@ -117,6 +117,7 @@ describe('The autoNumeric object', () => {
         defaultValueOverride         : null,
         unformatOnSubmit             : false,
         outputFormat                 : null,
+        isCancellable                : true,
         showWarnings                 : true,
         failOnUnknownOption          : false,
     };
@@ -1631,6 +1632,11 @@ describe('Static autoNumeric functions', () => {
             expect(() => an.validate({ outputFormat: '.-' })).not.toThrow();
             expect(() => an.validate({ outputFormat: ',-' })).not.toThrow();
 
+            expect(() => an.validate({ isCancellable: true })).not.toThrow();
+            expect(() => an.validate({ isCancellable: false })).not.toThrow();
+            expect(() => an.validate({ isCancellable: 'true' })).not.toThrow();
+            expect(() => an.validate({ isCancellable: 'false' })).not.toThrow();
+
             expect(() => an.validate({ showWarnings: true })).not.toThrow();
             expect(() => an.validate({ showWarnings: false })).not.toThrow();
             expect(() => an.validate({ showWarnings: 'true' })).not.toThrow();
@@ -1871,6 +1877,12 @@ describe('Static autoNumeric functions', () => {
             expect(() => an.validate({ outputFormat: '-5' })).toThrow();
             expect(() => an.validate({ outputFormat: 5 })).toThrow();
             expect(() => an.validate({ outputFormat: -5 })).toThrow();
+
+            expect(() => an.validate({ isCancellable: 0 })).toThrow();
+            expect(() => an.validate({ isCancellable: 1 })).toThrow();
+            expect(() => an.validate({ isCancellable: '0' })).toThrow();
+            expect(() => an.validate({ isCancellable: '1' })).toThrow();
+            expect(() => an.validate({ isCancellable: 'foobar' })).toThrow();
 
             expect(() => an.validate({ showWarnings: 0 })).toThrow();
             expect(() => an.validate({ showWarnings: 1 })).toThrow();


### PR DESCRIPTION
Fix issue #387 Add a 'cancellable' feature
Fix issue #391 The currency symbol is selected when focusing on an input via the `Tab` key, when `selectNumberOnly` is set to `true`

Refactor the code to create a `_selectOnlyNumbers()` function that extract that behavior for re-use.
Create a `_select()` function that select the whole element content, while respecting the `selectNumberOnly` option.
Create a `_defaultSelectAll()` function that select the whole element content, including all characters.
Modify the `setElementSelection()` calls to simplify them with the ability to use one argument instead of two when the `start` and `end` position are the same.
Add a feature where when the user hit 'Escape', the element content is selected (cf. issue #387).